### PR TITLE
Multiread support for OneToOne and OneToMany

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -30,6 +30,7 @@ type OneToOneTable interface {
 	Update(id interface{}, m map[string]interface{}) error
 	Delete(id interface{}) error
 	Read(id interface{}) (interface{}, error)
+	MultiRead(ids ...interface{}) ([]interface{}, error)
 	TableChanger
 }
 
@@ -45,6 +46,7 @@ type OneToManyTable interface {
 	DeleteAll(v interface{}) error
 	List(v, startId interface{}, limit int) ([]interface{}, error)
 	Read(v, id interface{}) (interface{}, error)
+	MultiRead(id interface{}, ids ...interface{}) ([]interface{}, error)
 	TableChanger
 }
 

--- a/one_to_many_table.go
+++ b/one_to_many_table.go
@@ -34,6 +34,14 @@ func (o *oneToManyT) Read(field, id interface{}) (interface{}, error) {
 	return res[0], nil
 }
 
+func (o *oneToManyT) MultiRead(field interface{}, ids ...interface{}) ([]interface{}, error) {
+	res, err := o.Where(Eq(o.fieldToIndexBy, field), In(o.idField, ids...)).Query().Read()
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
 func (o *oneToManyT) List(field, startId interface{}, limit int) ([]interface{}, error) {
 	return o.Where(Eq(o.fieldToIndexBy, field), GTE(o.idField, startId)).Query().Limit(limit).Read()
 }

--- a/one_to_many_table_test.go
+++ b/one_to_many_table_test.go
@@ -77,3 +77,39 @@ func TestOneToManyTableDelete(t *testing.T) {
 		t.Fatal(c, err)
 	}
 }
+
+func TestOneToManyTableMultiRead(t *testing.T) {
+	tbl := ns.OneToManyTable("customer93", "Tag", "Id", Customer2{})
+	createIf(tbl.(TableChanger), t)
+	joe := Customer2{
+		Id:   "33",
+		Name: "Joe",
+		Tag:  "A",
+	}
+	err := tbl.Set(joe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jane := Customer2{
+		Id:   "34",
+		Name: "Jane",
+		Tag:  "A",
+	}
+	err = tbl.Set(jane)
+	if err != nil {
+		t.Fatal(err)
+	}
+	customers, err := tbl.MultiRead("A", "33", "34")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(customers) != 2 {
+		t.Fatal("Expected to multiread 2 records, got %d", len(customers))
+	}
+	if !reflect.DeepEqual(customers[0].(*Customer2), &joe) {
+		t.Fatal("Expected to find joe, got %v", customers[0])
+	}
+	if !reflect.DeepEqual(customers[1].(*Customer2), &jane) {
+		t.Fatal("Expected to find jane, got %v", customers[1])
+	}
+}

--- a/one_to_one_table.go
+++ b/one_to_one_table.go
@@ -28,3 +28,11 @@ func (o *oneToOneT) Read(id interface{}) (interface{}, error) {
 	}
 	return res[0], nil
 }
+
+func (o *oneToOneT) MultiRead(ids ...interface{}) ([]interface{}, error) {
+	res, err := o.Where(In(o.idField, ids...)).Query().Read()
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}

--- a/one_to_one_table_test.go
+++ b/one_to_one_table_test.go
@@ -65,3 +65,37 @@ func TestOneToOneTableUpdate(t *testing.T) {
 		t.Fatal(c)
 	}
 }
+
+func TestOneToOneTableMultiRead(t *testing.T) {
+	tbl := ns.OneToOneTable("customer83", "Id", Customer{})
+	createIf(tbl.(TableChanger), t)
+	joe := Customer{
+		Id:   "33",
+		Name: "Joe",
+	}
+	err := tbl.Set(joe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jane := Customer{
+		Id:   "34",
+		Name: "Jane",
+	}
+	err = tbl.Set(jane)
+	if err != nil {
+		t.Fatal(err)
+	}
+	customers, err := tbl.MultiRead("33", "34")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(customers) != 2 {
+		t.Fatal("Expected to multiread 2 records, got %d", len(customers))
+	}
+	if !reflect.DeepEqual(customers[0].(*Customer), &joe) {
+		t.Fatal("Expected to find joe, got %v", customers[0])
+	}
+	if !reflect.DeepEqual(customers[1].(*Customer), &jane) {
+		t.Fatal("Expected to find jane, got %v", customers[1])
+	}
+}


### PR DESCRIPTION
This PR adds multiread support to `OneToOneTable` and `OneToManyTable`. Multireads will generate queries of the form:

```
SELECT * FROM foo WHERE id IN (1, 2, 3)
```
