### PR TITLE
Prepare for mocking

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -73,8 +73,10 @@ func (c *connection) DropKeySpace(name string) error {
 }
 
 func (c *connection) KeySpace(name string) KeySpace {
-	return &k{
+	k := &k{
 		qe:   c.q,
 		name: name,
 	}
+	k.tableFactory = k
+	return k
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -32,8 +32,8 @@ type OneToOneTable interface {
 	UpdateWithOptions(id interface{}, m map[string]interface{}, opts Options) error
 	Update(id interface{}, m map[string]interface{}) error
 	Delete(id interface{}) error
-	Read(id interface{}) (interface{}, error)
-	MultiRead(ids ...interface{}) ([]interface{}, error)
+	Read(id, pointer interface{}) error
+	MultiRead(ids []interface{}, pointerToASlice interface{}) error
 	TableChanger
 }
 
@@ -49,9 +49,9 @@ type OneToManyTable interface {
 	Update(v, id interface{}, m map[string]interface{}) error
 	Delete(v, id interface{}) error
 	DeleteAll(v interface{}) error
-	List(v, startId interface{}, limit int) ([]interface{}, error)
-	Read(v, id interface{}) (interface{}, error)
-	MultiRead(id interface{}, ids ...interface{}) ([]interface{}, error)
+	List(v, startId interface{}, limit int, pointerToASlice interface{}) error
+	Read(v, id, pointer interface{}) error
+	MultiRead(id interface{}, ids []interface{}, pointerToASlice interface{}) error
 	TableChanger
 }
 
@@ -66,8 +66,8 @@ type TimeSeriesTable interface {
 	Set(v interface{}) error
 	UpdateWithOptions(timeStamp time.Time, id interface{}, m map[string]interface{}, opts Options) error
 	Update(timeStamp time.Time, id interface{}, m map[string]interface{}) error
-	List(start, end time.Time) ([]interface{}, error)
-	Read(timeStamp time.Time, id interface{}) (interface{}, error)
+	List(start, end time.Time, pointerToASlice interface{}) error
+	Read(timeStamp time.Time, id, pointer interface{}) error
 	Delete(timeStamp time.Time, id interface{}) error
 	TableChanger
 }
@@ -83,8 +83,8 @@ type TimeSeriesBTable interface {
 	Set(v interface{}) error
 	UpdateWithOptions(v interface{}, timeStamp time.Time, id interface{}, m map[string]interface{}, opts Options) error
 	Update(v interface{}, timeStamp time.Time, id interface{}, m map[string]interface{}) error
-	List(v interface{}, start, end time.Time) ([]interface{}, error)
-	Read(v interface{}, timeStamp time.Time, id interface{}) (interface{}, error)
+	List(v interface{}, start, end time.Time, pointerToASlice interface{}) error
+	Read(v interface{}, timeStamp time.Time, id, pointer interface{}) error
 	Delete(v interface{}, timeStamp time.Time, id interface{}) error
 	TableChanger
 }
@@ -95,7 +95,8 @@ type TimeSeriesBTable interface {
 
 // A Query is a subset of a Table intended to be read
 type Query interface {
-	Read() ([]interface{}, error)
+	Read(pointerToASlice interface{}) error
+	ReadOne(pointer interface{}) error
 	Limit(int) Query
 }
 

--- a/one_to_many_table.go
+++ b/one_to_many_table.go
@@ -5,7 +5,7 @@ import (
 )
 
 type oneToManyT struct {
-	*t
+	Table
 	fieldToIndexBy string
 	idField        string
 }

--- a/one_to_many_table.go
+++ b/one_to_many_table.go
@@ -1,7 +1,7 @@
 package gocassa
 
 import (
-	"fmt"
+
 )
 
 type oneToManyT struct {
@@ -26,20 +26,14 @@ func (o *oneToManyT) DeleteAll(field interface{}) error {
 	return o.Where(Eq(o.fieldToIndexBy, field)).Delete()
 }
 
-func (o *oneToManyT) Read(field, id interface{}) (interface{}, error) {
-	if res, err := o.Where(Eq(o.fieldToIndexBy, field), Eq(o.idField, id)).Query().Read(); err != nil {
-		return nil, err
-	} else if len(res) == 0 {
-		return nil, fmt.Errorf("Row with id %v not found", id)
-	} else {
-		return res[0], nil
-	}
+func (o *oneToManyT) Read(field, id, pointer interface{}) error {
+	return o.Where(Eq(o.fieldToIndexBy, field), Eq(o.idField, id)).Query().ReadOne(pointer)
 }
 
-func (o *oneToManyT) MultiRead(field interface{}, ids ...interface{}) ([]interface{}, error) {
-	return o.Where(Eq(o.fieldToIndexBy, field), In(o.idField, ids...)).Query().Read()
+func (o *oneToManyT) MultiRead(field interface{}, ids []interface{}, pointerToASlice interface{}) error {
+	return o.Where(Eq(o.fieldToIndexBy, field), In(o.idField, ids...)).Query().Read(pointerToASlice)
 }
 
-func (o *oneToManyT) List(field, startId interface{}, limit int) ([]interface{}, error) {
-	return o.Where(Eq(o.fieldToIndexBy, field), GTE(o.idField, startId)).Query().Limit(limit).Read()
+func (o *oneToManyT) List(field, startId interface{}, limit int, pointerToASlice interface{}) error {
+	return o.Where(Eq(o.fieldToIndexBy, field), GTE(o.idField, startId)).Query().Limit(limit).Read(pointerToASlice)
 }

--- a/one_to_many_table_test.go
+++ b/one_to_many_table_test.go
@@ -23,16 +23,17 @@ func TestOneToManyTableInsertRead(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c, err := tbl.Read("A", "33")
+	res := &Customer2{}
+	err = tbl.Read("A", "33", res)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(*(c.(*Customer2)), joe) {
-		t.Fatal(*(c.(*Customer2)), joe)
+	if !reflect.DeepEqual(*res, joe) {
+		t.Fatal(*res, joe)
 	}
-	c, err = tbl.Read("B", "33")
+	err = tbl.Read("B", "33", res)
 	if err == nil {
-		t.Fatal(c)
+		t.Fatal(*res)
 	}
 	err = tbl.Update("A", "33", map[string]interface{}{
 		"Name": "John",
@@ -40,12 +41,12 @@ func TestOneToManyTableInsertRead(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c, err = tbl.Read("A", "33")
+	err = tbl.Read("A", "33", res)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if c.(*Customer2).Name != "John" {
-		t.Fatal(c)
+	if res.Name != "John" {
+		t.Fatal(*res)
 	}
 }
 
@@ -61,20 +62,21 @@ func TestOneToManyTableDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c, err := tbl.Read("A", "33")
+	res := &Customer2{}
+	err = tbl.Read("A", "33", res)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(*(c.(*Customer2)), joe) {
-		t.Fatal(*(c.(*Customer2)), joe)
+	if !reflect.DeepEqual(*res, joe) {
+		t.Fatal(*res, joe)
 	}
 	err = tbl.Delete("A", "33")
 	if err != nil {
 		t.Fatal(err)
 	}
-	c, err = tbl.Read("A", "33")
-	if err == nil || c != nil {
-		t.Fatal(c, err)
+	err = tbl.Read("A", "33", res)
+	if err == nil {
+		t.Fatal(res)
 	}
 }
 
@@ -99,17 +101,18 @@ func TestOneToManyTableMultiRead(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	customers, err := tbl.MultiRead("A", "33", "34")
+	customers := &[]Customer2{}
+	err = tbl.MultiRead("A", []interface{}{"33", "34"}, customers)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(customers) != 2 {
-		t.Fatal("Expected to multiread 2 records, got %d", len(customers))
+	if len(*customers) != 2 {
+		t.Fatal("Expected to multiread 2 records, got %d", len(*customers))
 	}
-	if !reflect.DeepEqual(customers[0].(*Customer2), &joe) {
-		t.Fatal("Expected to find joe, got %v", customers[0])
+	if !reflect.DeepEqual((*customers)[0], joe) {
+		t.Fatal("Expected to find joe, got %v", (*customers)[0])
 	}
-	if !reflect.DeepEqual(customers[1].(*Customer2), &jane) {
-		t.Fatal("Expected to find jane, got %v", customers[1])
+	if !reflect.DeepEqual((*customers)[1], jane) {
+		t.Fatal("Expected to find jane, got %v", (*customers)[1])
 	}
 }

--- a/one_to_one_table.go
+++ b/one_to_one_table.go
@@ -4,7 +4,7 @@ import (
 )
 
 type oneToOneT struct {
-	*t
+	Table
 	idField string
 }
 

--- a/one_to_one_table.go
+++ b/one_to_one_table.go
@@ -1,7 +1,6 @@
 package gocassa
 
 import (
-	"fmt"
 )
 
 type oneToOneT struct {
@@ -21,16 +20,10 @@ func (o *oneToOneT) Delete(id interface{}) error {
 	return o.Where(Eq(o.idField, id)).Delete()
 }
 
-func (o *oneToOneT) Read(id interface{}) (interface{}, error) {
-	if res, err := o.Where(Eq(o.idField, id)).Query().Read(); err != nil {
-		return nil, err
-	} else if len(res) == 0 {
-		return nil, fmt.Errorf("Row with id %v not found", id)
-	} else {
-		return res[0], nil
-	}
+func (o *oneToOneT) Read(id, pointer interface{}) error {
+	return o.Where(Eq(o.idField, id)).Query().ReadOne(pointer)
 }
 
-func (o *oneToOneT) MultiRead(ids ...interface{}) ([]interface{}, error) {
-	return o.Where(In(o.idField, ids...)).Query().Read()
+func (o *oneToOneT) MultiRead(ids []interface{}, pointerToASlice interface{}) error {
+	return o.Where(In(o.idField, ids...)).Query().Read(pointerToASlice)
 }

--- a/one_to_one_table_test.go
+++ b/one_to_one_table_test.go
@@ -16,20 +16,21 @@ func TestOneToOneTable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c, err := tbl.Read("33")
+	res := &Customer{}
+	err = tbl.Read("33", res)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(*(c.(*Customer)), joe) {
-		t.Fatal(*(c.(*Customer)), joe)
+	if !reflect.DeepEqual(*res, joe) {
+		t.Fatal(*res, joe)
 	}
 	err = tbl.Delete("33")
 	if err != nil {
 		t.Fatal(err)
 	}
-	c, err = tbl.Read("33")
-	if c != nil || err == nil {
-		t.Fatal(c, err)
+	err = tbl.Read("33", res)
+	if err == nil {
+		t.Fatal(res)
 	}
 }
 
@@ -44,12 +45,13 @@ func TestOneToOneTableUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c, err := tbl.Read("33")
+	res := &Customer{}
+	err = tbl.Read("33", res)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(*(c.(*Customer)), joe) {
-		t.Fatal(*(c.(*Customer)), joe)
+	if !reflect.DeepEqual(*res, joe) {
+		t.Fatal(*res, joe)
 	}
 	err = tbl.Update("33", map[string]interface{}{
 		"Name": "John",
@@ -57,12 +59,12 @@ func TestOneToOneTableUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c, err = tbl.Read("33")
+	err = tbl.Read("33", res)
 	if err != nil {
-		t.Fatal(c, err)
+		t.Fatal(res, err)
 	}
-	if c.(*Customer).Name != "John" {
-		t.Fatal(c)
+	if res.Name != "John" {
+		t.Fatal(res)
 	}
 }
 
@@ -85,17 +87,18 @@ func TestOneToOneTableMultiRead(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	customers, err := tbl.MultiRead("33", "34")
+	customers := &[]Customer{}
+	err = tbl.MultiRead([]interface{}{"33", "34"}, customers)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(customers) != 2 {
-		t.Fatal("Expected to multiread 2 records, got %d", len(customers))
+	if len(*customers) != 2 {
+		t.Fatal("Expected to multiread 2 records, got %d", len(*customers))
 	}
-	if !reflect.DeepEqual(customers[0].(*Customer), &joe) {
-		t.Fatal("Expected to find joe, got %v", customers[0])
+	if !reflect.DeepEqual((*customers)[0], joe) {
+		t.Fatal("Expected to find joe, got %v", (*customers)[0])
 	}
-	if !reflect.DeepEqual(customers[1].(*Customer), &jane) {
-		t.Fatal("Expected to find jane, got %v", customers[1])
+	if !reflect.DeepEqual((*customers)[1], jane) {
+		t.Fatal("Expected to find jane, got %v", (*customers)[1])
 	}
 }

--- a/query_test.go
+++ b/query_test.go
@@ -45,15 +45,16 @@ func TestEq(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := cs.Where(Eq("Id", "50")).Query().Read()
+	res := &[]Customer{}
+	err = cs.Where(Eq("Id", "50")).Query().Read(res)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(res) == 0 {
+	if len(*res) == 0 {
 		t.Fatal("Not found")
 	}
-	if res[0].(*Customer).Id != "50" {
-		t.Fatal(res[0].(*Customer))
+	if (*res)[0].Id != "50" {
+		t.Fatal((*res)[0])
 	}
 }
 
@@ -75,12 +76,13 @@ func TestMultipleRowResults(t *testing.T) {
 		Id:   "13",
 		Name: "John",
 	})
-	res, err := cs.Where(Eq("Name", "John")).Query().Read()
+	res := &[]Customer{}
+	err = cs.Where(Eq("Name", "John")).Query().Read(res)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(res) != 2 {
-		t.Fatal(len(res), res)
+	if len(*res) != 2 {
+		t.Fatal(res)
 	}
 }
 
@@ -100,15 +102,16 @@ func TestIn(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := cs.Where(In("Id", "100", "200")).Query().Read()
-	if len(res) != 2 {
-		for _, v := range res {
-			fmt.Println(*(v.(*Customer)))
+	res := &[]Customer{}
+	err = cs.Where(In("Id", "100", "200")).Query().Read(res)
+	if len(*res) != 2 {
+		for _, v := range *res {
+			fmt.Println(v)
 		}
-		t.Fatal("Not found", len(res))
+		t.Fatal("Not found", res)
 	}
-	if res[0].(*Customer).Id != "100" || res[1].(*Customer).Id != "200" {
-		t.Fatal(res[0].(*Customer), res[1].(*Customer))
+	if (*res)[0].Id != "100" || (*res)[1].Id != "200" {
+		t.Fatal((*res)[0], (*res)[1])
 	}
 }
 
@@ -122,18 +125,20 @@ func TestAnd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := cs.Where(Eq("Id", "100"), Eq("Name", "Joe")).Query().Read()
+	res := &[]Customer{}
+	err = cs.Where(Eq("Id", "100"), Eq("Name", "Joe")).Query().Read(res)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(res) != 1 {
-		t.Fatal("Not found ", len(res))
+	if len(*res) != 1 {
+		t.Fatal("Not found ", res)
 	}
 }
 
 func TestQueryReturnError(t *testing.T) {
 	cs := ns.Table("customer2", Customer{}, Keys{})
-	_, err := cs.Where(Eq("Id", "100"), Eq("Name", "Joe")).Query().Read()
+	res := &[]Customer{}
+	err := cs.Where(Eq("Id", "100"), Eq("Name", "Joe")).Query().Read(res)
 	if err == nil {
 		t.Fatal("Table customer2 does not exist - should return error")
 	}
@@ -166,14 +171,15 @@ func TestTypesMarshal(t *testing.T) {
 	if err := tbl.Set(c); err != nil {
 		t.Fatal(err)
 	}
-	res, err := tbl.Where(Eq("Id", "1")).Query().Read()
+	res := &[]Customer3{}
+	err := tbl.Where(Eq("Id", "1")).Query().Read(res)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(res) != 1 {
+	if len(*res) != 1 {
 		t.Fatal(res)
 	}
-	if !reflect.DeepEqual(c, *res[0].(*Customer3)) {
-		t.Fatal(c, *res[0].(*Customer3))
+	if !reflect.DeepEqual(c, (*res)[0]) {
+		t.Fatal(c, (*res)[0])
 	}
 }

--- a/reflect/reflect.go
+++ b/reflect/reflect.go
@@ -29,7 +29,7 @@ func MapToStruct(m map[string]interface{}, struc interface{}) error {
 	val := r.Indirect(r.ValueOf(struc))
 	for k, v := range m {
 		structField := val.FieldByName(k)
-		if structField.Type().Name() == r.TypeOf(v).Name() {
+		if structField.IsValid() && structField.Type().Name() == r.TypeOf(v).Name() {
 			structField.Set(r.ValueOf(v))
 		}
 	}

--- a/table_test.go
+++ b/table_test.go
@@ -39,12 +39,13 @@ func TestCreateTable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := cs.Where(Eq("Id", "1001"), Eq("Name", "Joe")).Query().Read()
+	res := &[]Customer{}
+	err = cs.Where(Eq("Id", "1001"), Eq("Name", "Joe")).Query().Read(res)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(res) != 1 {
-		t.Fatal("Not found ", len(res))
+	if len(*res) != 1 {
+		t.Fatal("Not found ", len(*res))
 	}
 	err = ns.(*k).DropTable(name)
 	if err != nil {

--- a/timeseries_table.go
+++ b/timeseries_table.go
@@ -8,7 +8,7 @@ import (
 const bucketFieldName = "bucket"
 
 type timeSeriesT struct {
-	*t
+	Table
 	timeField  string
 	idField    string
 	bucketSize time.Duration
@@ -24,7 +24,7 @@ func (o *timeSeriesT) SetWithOptions(v interface{}, opts Options) error {
 	} else {
 		m[bucketFieldName] = o.bucket(tim.Unix())
 	}
-	return o.t.SetWithOptions(m, opts)
+	return o.Table.SetWithOptions(m, opts)
 }
 
 func (o *timeSeriesT) Set(v interface{}) error {

--- a/timeseries_table_test.go
+++ b/timeseries_table_test.go
@@ -49,21 +49,23 @@ func TestTimeSeriesT(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ts, err := tbl.List(parse("2006 Jan 2 15:03:58"), parse("2006 Jan 2 15:04:02"))
+	ts := &[]Trip{}
+	err = tbl.List(parse("2006 Jan 2 15:03:58"), parse("2006 Jan 2 15:04:02"), ts)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ts) != 3 {
+	if len(*ts) != 3 {
 		t.Fatal(ts)
 	}
-	if ts[0].(*Trip).Id != "1" || ts[1].(*Trip).Id != "2" || ts[2].(*Trip).Id != "3" {
-		t.Fatal(ts[0].(*Trip), ts[1].(*Trip), ts[2].(*Trip))
+	ts1 := *ts
+	if ts1[0].Id != "1" || ts1[1].Id != "2" || ts1[2].Id != "3" {
+		t.Fatal(ts1[0], ts1[1], ts1[2])
 	}
-	ts, err = tbl.List(parse("2006 Jan 2 15:03:58"), parse("2006 Jan 2 15:05:02"))
+	err = tbl.List(parse("2006 Jan 2 15:03:58"), parse("2006 Jan 2 15:05:02"), ts)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ts) != 4 {
+	if len(*ts) != 4 {
 		t.Fatal(ts)
 	}
 }

--- a/timeseriesb_table.go
+++ b/timeseriesb_table.go
@@ -6,7 +6,7 @@ import (
 )
 
 type timeSeriesBT struct {
-	*t
+	Table
 	indexField string
 	timeField  string
 	idField    string
@@ -23,7 +23,7 @@ func (o *timeSeriesBT) SetWithOptions(v interface{}, opts Options) error {
 	} else {
 		m[bucketFieldName] = o.bucket(tim.Unix())
 	}
-	return o.t.SetWithOptions(m, opts)
+	return o.Table.SetWithOptions(m, opts)
 }
 
 func (o *timeSeriesBT) Set(v interface{}) error {

--- a/timeseriesb_table.go
+++ b/timeseriesb_table.go
@@ -2,7 +2,6 @@ package gocassa
 
 import (
 	"errors"
-	"fmt"
 	"time"
 )
 
@@ -50,18 +49,13 @@ func (o *timeSeriesBT) Delete(v interface{}, timeStamp time.Time, id interface{}
 	return o.Where(Eq(o.indexField, v), Eq(bucketFieldName, bucket), Eq(o.timeField, timeStamp), Eq(o.idField, id)).Delete()
 }
 
-func (o *timeSeriesBT) Read(v interface{}, timeStamp time.Time, id interface{}) (interface{}, error) {
+func (o *timeSeriesBT) Read(v interface{}, timeStamp time.Time, id, pointer interface{}) error {
 	bucket := o.bucket(timeStamp.Unix())
-	if res, err := o.Where(Eq(o.indexField, v), Eq(bucketFieldName, bucket), Eq(o.timeField, timeStamp), Eq(o.idField, id)).Query().Read(); err != nil {
-		return nil, err
-	} else if len(res) == 0 {
-		return nil, fmt.Errorf("Row with id %v not found", id)
-	} else {
-		return res[0], nil
-	}
+	return o.Where(Eq(o.indexField, v), Eq(bucketFieldName, bucket), Eq(o.timeField, timeStamp), Eq(o.idField, id)).Query().ReadOne(pointer)
+
 }
 
-func (o *timeSeriesBT) List(v interface{}, startTime time.Time, endTime time.Time) ([]interface{}, error) {
+func (o *timeSeriesBT) List(v interface{}, startTime time.Time, endTime time.Time, pointerToASlice interface{}) error {
 	buckets := []interface{}{}
 	start := o.bucket(startTime.Unix())
 	for i := start; ; i += int64(o.bucketSize/time.Second) * 1000 {
@@ -70,5 +64,5 @@ func (o *timeSeriesBT) List(v interface{}, startTime time.Time, endTime time.Tim
 		}
 		buckets = append(buckets, i)
 	}
-	return o.Where(Eq(o.indexField, v), In(bucketFieldName, buckets...), GTE(o.timeField, startTime), LTE(o.timeField, endTime)).Query().Read()
+	return o.Where(Eq(o.indexField, v), In(bucketFieldName, buckets...), GTE(o.timeField, startTime), LTE(o.timeField, endTime)).Query().Read(pointerToASlice)
 }

--- a/timeseriesb_table_test.go
+++ b/timeseriesb_table_test.go
@@ -46,38 +46,41 @@ func TestTimeSeriesBT(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ts, err := tbl.List("A", parse("2006 Jan 2 15:03:58"), parse("2006 Jan 2 15:04:02"))
+	ts := &[]TripB{}
+	err = tbl.List("A", parse("2006 Jan 2 15:03:58"), parse("2006 Jan 2 15:04:02"), ts)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ts) != 2 {
+	if len(*ts) != 2 {
 		t.Fatal(ts)
 	}
-	if ts[0].(*TripB).Id != "1" || ts[1].(*TripB).Id != "3" {
-		t.Fatal(ts[0].(*TripB), ts[1].(*TripB))
+	ts1 := *ts
+	if ts1[0].Id != "1" || ts1[1].Id != "3" {
+		t.Fatal(ts1[0], ts1[1])
 	}
-	ts, err = tbl.List("B", parse("2006 Jan 2 15:03:58"), parse("2006 Jan 2 15:04:02"))
+	err = tbl.List("B", parse("2006 Jan 2 15:03:58"), parse("2006 Jan 2 15:04:02"), ts)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ts) != 1 {
+	if len(*ts) != 1 {
 		t.Fatal(ts)
 	}
-	if ts[0].(*TripB).Id != "2" {
-		t.Fatal(ts[0].(*TripB))
+	ts1 = *ts
+	if ts1[0].Id != "2" {
+		t.Fatal(ts1[0])
 	}
-	ts, err = tbl.List("B", parse("2006 Jan 2 15:03:58"), parse("2006 Jan 2 15:05:02"))
+	err = tbl.List("B", parse("2006 Jan 2 15:03:58"), parse("2006 Jan 2 15:05:02"), ts)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ts) != 2 {
+	if len(*ts) != 2 {
 		t.Fatal(ts)
 	}
-	ts, err = tbl.List("B", parse("2006 Jan 2 15:03:58"), parse("2006 Jan 2 15:05:00"))
+	err = tbl.List("B", parse("2006 Jan 2 15:03:58"), parse("2006 Jan 2 15:05:00"), ts)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ts) != 1 {
+	if len(*ts) != 1 {
 		t.Fatal(ts)
 	}
 }


### PR DESCRIPTION
Changes:
- `oneToOneT`, `oneToManyT`, `timeSeriesT` and `timeSeriesBT` now embed `Table` rather `t`. Their behavior can thus be changed just by embedding a different `Table` (e.g. an in-memory table).
- `k` (keyspace) now has a `tableFactory` field for overriding how tables are constructed. This is used for creating in-memory tables.
