### PR TITLE
Prepare for mocking

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -73,8 +73,10 @@ func (c *connection) DropKeySpace(name string) error {
 }
 
 func (c *connection) KeySpace(name string) KeySpace {
-	return &k{
+	k := &k{
 		qe:   c.q,
 		name: name,
 	}
+	k.tableFactory = k
+	return k
 }

--- a/one_to_many_table.go
+++ b/one_to_many_table.go
@@ -5,7 +5,7 @@ import (
 )
 
 type oneToManyT struct {
-	*t
+	Table
 	fieldToIndexBy string
 	idField        string
 }

--- a/one_to_one_table.go
+++ b/one_to_one_table.go
@@ -4,7 +4,7 @@ import (
 )
 
 type oneToOneT struct {
-	*t
+	Table
 	idField string
 }
 

--- a/reflect/reflect.go
+++ b/reflect/reflect.go
@@ -29,7 +29,7 @@ func MapToStruct(m map[string]interface{}, struc interface{}) error {
 	val := r.Indirect(r.ValueOf(struc))
 	for k, v := range m {
 		structField := val.FieldByName(k)
-		if structField.Type().Name() == r.TypeOf(v).Name() {
+		if structField.IsValid() && structField.Type().Name() == r.TypeOf(v).Name() {
 			structField.Set(r.ValueOf(v))
 		}
 	}

--- a/timeseries_table.go
+++ b/timeseries_table.go
@@ -8,7 +8,7 @@ import (
 const bucketFieldName = "bucket"
 
 type timeSeriesT struct {
-	*t
+	Table
 	timeField  string
 	idField    string
 	bucketSize time.Duration
@@ -24,7 +24,7 @@ func (o *timeSeriesT) SetWithOptions(v interface{}, opts Options) error {
 	} else {
 		m[bucketFieldName] = o.bucket(tim.Unix())
 	}
-	return o.t.SetWithOptions(m, opts)
+	return o.Table.SetWithOptions(m, opts)
 }
 
 func (o *timeSeriesT) Set(v interface{}) error {

--- a/timeseriesb_table.go
+++ b/timeseriesb_table.go
@@ -6,7 +6,7 @@ import (
 )
 
 type timeSeriesBT struct {
-	*t
+	Table
 	indexField string
 	timeField  string
 	idField    string
@@ -23,7 +23,7 @@ func (o *timeSeriesBT) SetWithOptions(v interface{}, opts Options) error {
 	} else {
 		m[bucketFieldName] = o.bucket(tim.Unix())
 	}
-	return o.t.SetWithOptions(m, opts)
+	return o.Table.SetWithOptions(m, opts)
 }
 
 func (o *timeSeriesBT) Set(v interface{}) error {


### PR DESCRIPTION
Changes:
- `oneToOneT`, `oneToManyT`, `timeSeriesT` and `timeSeriesBT` now embed `Table` rather `t`. Their behavior can thus be changed just by embedding a different `Table` (e.g. an in-memory table).
- `k` (keyspace) now has a `tableFactory` field for overriding how tables are constructed. This is used for creating in-memory tables.
