### PR TITLE
Allow creation of a KeySpace with a given QueryExecutor

### DIFF
--- a/keyspace.go
+++ b/keyspace.go
@@ -20,6 +20,13 @@ func ConnectToKeySpace(keySpace string, nodeIps []string, username, password str
 	return c.KeySpace(keySpace), nil
 }
 
+func KeySpaceWithExecutor(keySpace string, qe QueryExecutor) (KeySpace, error) {
+	return &k{
+		qe:   qe,
+		name: keySpace,
+	}, nil
+}
+
 func (k *k) DebugMode(b bool) {
 	k.debugMode = true
 }


### PR DESCRIPTION
The current `QueryExecutor` functionality is not useable as there is no provision to get a `KeySpace` using a custom implementation. This addresses that need.

I have a full connection implementation in the go-service-layer that depends on this functionality.
