### PR TITLE
Clean up WHERE clause generation

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -35,6 +35,7 @@ type OneToOneTable interface {
 	Read(id, pointer interface{}) error
 	MultiRead(ids []interface{}, pointerToASlice interface{}) error
 	TableChanger
+	Selectable
 }
 
 //
@@ -53,6 +54,7 @@ type OneToManyTable interface {
 	Read(v, id, pointer interface{}) error
 	MultiRead(id interface{}, ids []interface{}, pointerToASlice interface{}) error
 	TableChanger
+	Selectable
 }
 
 //
@@ -70,6 +72,7 @@ type TimeSeriesTable interface {
 	Read(timeStamp time.Time, id, pointer interface{}) error
 	Delete(timeStamp time.Time, id interface{}) error
 	TableChanger
+	Selectable
 }
 
 //
@@ -87,6 +90,7 @@ type TimeSeriesBTable interface {
 	Read(v interface{}, timeStamp time.Time, id, pointer interface{}) error
 	Delete(v interface{}, timeStamp time.Time, id interface{}) error
 	TableChanger
+	Selectable
 }
 
 //
@@ -125,13 +129,17 @@ type TableChanger interface {
 	//CreateIfDoesNotExist() error
 }
 
+type Selectable interface {
+	Where(relations ...Relation) Filter // Because we provide selections
+}
+
 type Table interface {
 	// Set Inserts, or Replaces your row with the supplied struct. Be aware that what is not in your struct
 	// will be deleted. To only overwrite some of the fields, use Query.Update.
 	Set(v interface{}) error
 	SetWithOptions(v interface{}, opts Options) error
-	Where(relations ...Relation) Filter // Because we provide selections
 	TableChanger
+	Selectable
 }
 
 type QueryExecutor interface {

--- a/interfaces.go
+++ b/interfaces.go
@@ -35,7 +35,6 @@ type OneToOneTable interface {
 	Read(id, pointer interface{}) error
 	MultiRead(ids []interface{}, pointerToASlice interface{}) error
 	TableChanger
-	Selectable
 }
 
 //
@@ -54,7 +53,6 @@ type OneToManyTable interface {
 	Read(v, id, pointer interface{}) error
 	MultiRead(id interface{}, ids []interface{}, pointerToASlice interface{}) error
 	TableChanger
-	Selectable
 }
 
 //
@@ -72,7 +70,6 @@ type TimeSeriesTable interface {
 	Read(timeStamp time.Time, id, pointer interface{}) error
 	Delete(timeStamp time.Time, id interface{}) error
 	TableChanger
-	Selectable
 }
 
 //
@@ -90,7 +87,6 @@ type TimeSeriesBTable interface {
 	Read(v interface{}, timeStamp time.Time, id, pointer interface{}) error
 	Delete(v interface{}, timeStamp time.Time, id interface{}) error
 	TableChanger
-	Selectable
 }
 
 //
@@ -129,17 +125,13 @@ type TableChanger interface {
 	//CreateIfDoesNotExist() error
 }
 
-type Selectable interface {
-	Where(relations ...Relation) Filter // Because we provide selections
-}
-
 type Table interface {
 	// Set Inserts, or Replaces your row with the supplied struct. Be aware that what is not in your struct
 	// will be deleted. To only overwrite some of the fields, use Query.Update.
 	Set(v interface{}) error
 	SetWithOptions(v interface{}, opts Options) error
+	Where(relations ...Relation) Filter // Because we provide selections
 	TableChanger
-	Selectable
 }
 
 type QueryExecutor interface {

--- a/interfaces.go
+++ b/interfaces.go
@@ -131,6 +131,8 @@ type Table interface {
 	Set(v interface{}) error
 	SetWithOptions(v interface{}, opts Options) error
 	Where(relations ...Relation) Filter // Because we provide selections
+	// Name returns the underlying table name, as stored in C*
+	Name() string
 	TableChanger
 }
 

--- a/one_to_many_table.go
+++ b/one_to_many_table.go
@@ -1,9 +1,5 @@
 package gocassa
 
-import (
-
-)
-
 type oneToManyT struct {
 	*t
 	fieldToIndexBy string

--- a/one_to_one_table.go
+++ b/one_to_one_table.go
@@ -1,8 +1,5 @@
 package gocassa
 
-import (
-)
-
 type oneToOneT struct {
 	*t
 	idField string

--- a/query.go
+++ b/query.go
@@ -50,15 +50,15 @@ func (q *query) generateRead() (string, []interface{}) {
 	l, lv := q.generateLimit()
 	str := fmt.Sprintf("SELECT %s FROM %s.%s", q.f.t.generateFieldNames(), q.f.t.keySpace.name, q.f.t.info.name)
 	vals := []interface{}{}
-	if len(w) > 0 {
+	if w != "" {
 		str += " " + w
 		vals = append(vals, wv...)
 	}
-	if len(o) > 0 {
+	if o != "" {
 		str += " " + o
 		vals = append(vals, ov...)
 	}
-	if len(l) > 0 {
+	if l != "" {
 		str += " " + l
 		vals = append(vals, lv...)
 	}

--- a/table.go
+++ b/table.go
@@ -168,6 +168,10 @@ func (t t) CreateStatement() (string, error) {
 		t.info.fieldValues)
 }
 
+func (t t) Name() string {
+	return t.info.name
+}
+
 //const (
 //	asc	 = iota
 //	desc


### PR DESCRIPTION
- Clean up `WHERE` statement construction
- Don't output a `WHERE` clause if there are no actual predicates within it
- Add a `Name()` method to `Table`, returning its underlying name as stored in C*
