### PR TITLE
Add some additional functions to the KeySpace/TableChanger interface

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -41,6 +41,7 @@ type MapTable interface {
 	Delete(id interface{}) Op
 	Read(id, pointer interface{}) Op
 	MultiRead(ids []interface{}, pointerToASlice interface{}) Op
+	Name() string
 	TableChanger
 }
 
@@ -59,6 +60,7 @@ type MultimapTable interface {
 	List(v, startId interface{}, limit int, pointerToASlice interface{}) Op
 	Read(v, id, pointer interface{}) Op
 	MultiRead(v interface{}, ids []interface{}, pointerToASlice interface{}) Op
+	Name() string
 	TableChanger
 }
 
@@ -76,6 +78,7 @@ type TimeSeriesTable interface {
 	Delete(timeStamp time.Time, id interface{}) Op
 	Read(timeStamp time.Time, id, pointer interface{}) Op
 	List(start, end time.Time, pointerToASlice interface{}) Op
+	Name() string
 	TableChanger
 }
 
@@ -93,6 +96,7 @@ type MultiTimeSeriesTable interface {
 	Delete(v interface{}, timeStamp time.Time, id interface{}) Op
 	Read(v interface{}, timeStamp time.Time, id, pointer interface{}) Op
 	List(v interface{}, start, end time.Time, pointerToASlice interface{}) Op
+	Name() string
 	TableChanger
 }
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -124,7 +124,7 @@ type Keys struct {
 type Op interface {
 	Run() error
 	// You do not need this in 95% of the use cases, use Run!
-	// Using atmoic batched writes (logged batches in Cassandra terminolohu) comes at a high performance cost!
+	// Using atomic batched writes (logged batches in Cassandra terminolohu) comes at a high performance cost!
 	RunAtomically() error
 	Add(...Op) Op
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -19,6 +19,8 @@ type KeySpace interface {
 	MultiTimeSeriesTable(tableName, fieldToIndexByField, timeField, uniqueKey string, bucketSize time.Duration, row interface{}) MultiTimeSeriesTable
 	Table(tableName string, row interface{}, keys Keys) Table
 	DebugMode(bool)
+	// Name returns the keyspace name as in C*
+	Name() string
 	// QueryExecutor returns the configured executor for this KeySpace
 	QueryExecutor() QueryExecutor
 	// Tables returns the name of all configured column families in this keyspace

--- a/interfaces.go
+++ b/interfaces.go
@@ -24,8 +24,6 @@ type KeySpace interface {
 	DebugMode(bool)
 	// Name returns the keyspace name as in C*
 	Name() string
-	// QueryExecutor returns the configured executor for this KeySpace
-	QueryExecutor() QueryExecutor
 	// Tables returns the name of all configured column families in this keyspace
 	Tables() ([]string, error)
 	// Exists returns whether the specified column family exists within the keyspace

--- a/interfaces.go
+++ b/interfaces.go
@@ -19,6 +19,14 @@ type KeySpace interface {
 	MultiTimeSeriesTable(tableName, fieldToIndexByField, timeField, uniqueKey string, bucketSize time.Duration, row interface{}) MultiTimeSeriesTable
 	Table(tableName string, row interface{}, keys Keys) Table
 	DebugMode(bool)
+	// QueryExecutor returns the configured executor for this KeySpace
+	QueryExecutor() QueryExecutor
+	// Name returns the name of the keyspace, as in C*
+	Name() string
+	// Tables returns the name of all configured column families in this keyspace
+	Tables() ([]string, error)
+	// Exists returns whether the specified column family exists within the keyspace
+	Exists(string) (bool, error)
 }
 
 //

--- a/interfaces.go
+++ b/interfaces.go
@@ -21,8 +21,6 @@ type KeySpace interface {
 	DebugMode(bool)
 	// QueryExecutor returns the configured executor for this KeySpace
 	QueryExecutor() QueryExecutor
-	// Name returns the name of the keyspace, as in C*
-	Name() string
 	// Tables returns the name of all configured column families in this keyspace
 	Tables() ([]string, error)
 	// Exists returns whether the specified column family exists within the keyspace
@@ -41,7 +39,6 @@ type MapTable interface {
 	Delete(id interface{}) Op
 	Read(id, pointer interface{}) Op
 	MultiRead(ids []interface{}, pointerToASlice interface{}) Op
-	Name() string
 	TableChanger
 }
 
@@ -60,7 +57,6 @@ type MultimapTable interface {
 	List(v, startId interface{}, limit int, pointerToASlice interface{}) Op
 	Read(v, id, pointer interface{}) Op
 	MultiRead(v interface{}, ids []interface{}, pointerToASlice interface{}) Op
-	Name() string
 	TableChanger
 }
 
@@ -78,7 +74,6 @@ type TimeSeriesTable interface {
 	Delete(timeStamp time.Time, id interface{}) Op
 	Read(timeStamp time.Time, id, pointer interface{}) Op
 	List(start, end time.Time, pointerToASlice interface{}) Op
-	Name() string
 	TableChanger
 }
 
@@ -96,7 +91,6 @@ type MultiTimeSeriesTable interface {
 	Delete(v interface{}, timeStamp time.Time, id interface{}) Op
 	Read(v interface{}, timeStamp time.Time, id, pointer interface{}) Op
 	List(v interface{}, start, end time.Time, pointerToASlice interface{}) Op
-	Name() string
 	TableChanger
 }
 
@@ -140,6 +134,8 @@ type TableChanger interface {
 	Create() error
 	CreateStatement() (string, error)
 	Recreate() error
+	// Name returns the name of the keyspace, as in C*
+	Name() string
 	//Drop() error
 	//CreateIfDoesNotExist() error
 }
@@ -151,7 +147,6 @@ type Table interface {
 	SetWithOptions(v interface{}, opts Options) Op
 	Where(relations ...Relation) Filter // Because we provide selections
 	// Name returns the underlying table name, as stored in C*
-	Name() string
 	TableChanger
 }
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -136,7 +136,7 @@ type TableChanger interface {
 	Create() error
 	CreateStatement() (string, error)
 	Recreate() error
-	// Name returns the name of the keyspace, as in C*
+	// Name returns the name of the table, as in C*
 	Name() string
 	//Drop() error
 	//CreateIfDoesNotExist() error

--- a/keyspace.go
+++ b/keyspace.go
@@ -107,8 +107,8 @@ func (k *k) MultiTimeSeriesTable(name, indexField, timeField, idField string, bu
 
 // Returns table names in a keyspace
 func (k *k) Tables() ([]string, error) {
-	stmt := fmt.Sprintf("SELECT columnfamily_name FROM system.schema_columnfamilies WHERE keyspace_name='%s'", k.name)
-	maps, err := k.qe.Query(stmt)
+	const stmt = "SELECT columnfamily_name FROM system.schema_columnfamilies WHERE keyspace_name = ?"
+	maps, err := k.qe.Query(stmt, k.name)
 	if err != nil {
 		return nil, err
 	}
@@ -135,6 +135,14 @@ func (k *k) Exists(cf string) (bool, error) {
 func (k *k) DropTable(cf string) error {
 	stmt := fmt.Sprintf("DROP TABLE IF EXISTS %s.%s", k.name, cf)
 	return k.qe.Execute(stmt)
+}
+
+func (k *k) QueryExecutor() QueryExecutor {
+	return k.qe
+}
+
+func (k *k) Name() string {
+	return k.name
 }
 
 // Translate errors returned by cassandra

--- a/keyspace.go
+++ b/keyspace.go
@@ -137,31 +137,6 @@ func (k *k) DropTable(cf string) error {
 	return k.qe.Execute(stmt)
 }
 
-func (k *k) QueryExecutor() QueryExecutor {
-	return k.qe
-}
-
 func (k *k) Name() string {
 	return k.name
-}
-
-// Translate errors returned by cassandra
-// Most of these should be checked after the appropriate commands only
-// or otherwise may give false positive results.
-//
-// PS: we shouldn't do this, really
-
-// Example: Cannot add existing keyspace "randKeyspace01"
-func isKeyspaceExistsError(s string) bool {
-	return strings.Contains(s, "exist")
-}
-
-func isTableExistsError(s string) bool {
-	return strings.Contains(s, "exist")
-}
-
-// unavailable
-// unconfigured columnfamily updtest1
-func isMissingKeyspaceOrTableError(s string) bool {
-	return strings.Contains(s, "unavailable") || strings.Contains(s, "unconfigured")
 }

--- a/query_test.go
+++ b/query_test.go
@@ -2,7 +2,9 @@ package gocassa
 
 import (
 	"fmt"
+	"os"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -13,10 +15,19 @@ type Customer struct {
 
 var ns KeySpace
 
+func getTestHosts() []string {
+	if h := os.Getenv("GOCASSA_TEST_HOSTS"); h != "" {
+		return strings.Split(h, ",")
+	} else {
+		return []string{"127.0.0.1"}
+	}
+}
+
 func init() {
 	kname := "test_ihopeudonthaveakeyspacenamedlikedthis"
 	var err error
-	c, err := Connect([]string{"127.0.0.1"}, "", "")
+
+	c, err := Connect(getTestHosts(), "", "")
 	if err != nil {
 		panic(err)
 	}
@@ -28,7 +39,7 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	ns, err = ConnectToKeySpace(kname, []string{"127.0.0.1"}, "", "")
+	ns, err = ConnectToKeySpace(kname, getTestHosts(), "", "")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
- `Tables()` and `Exists()` were already present on the underlying `table` object, but were not exposed
- `Name()` returns the underlying C\* name of a keyspace
- `QueryExecutor()` returns the configured `QueryExecutor` for the keyspace

Oh, and allow specification of a `GOCASSA_TEST_HOSTS` environment variable, to control which hosts+ports are used during testing.
