### PR TITLE
Use struct tags to determine column names

### DIFF
--- a/reflect/reflect.go
+++ b/reflect/reflect.go
@@ -2,12 +2,25 @@
 package reflect
 
 import (
-	// "fmt"
+	"fmt"
 	r "reflect"
-	//"strings"
+	"strings"
+	"sync"
 )
 
-// Converts a struct to a map.
+// StructToMap converts a struct to map. The object's default key string
+// is the struct field name but can be specified in the struct field's
+// tag value. The "cql" key in the struct field's tag value is the key
+// name. Examples:
+//
+//   // Field appears in the resulting map as key "myName".
+//   Field int `cql:"myName"`
+//
+//   // Field appears in the resulting as key "Field"
+//   Field int
+//
+//   // Field appears in the resulting map as key "myName"
+//   // Field int "myName"
 func StructToMap(val interface{}) (map[string]interface{}, bool) {
 	// indirect so function works with both structs and pointers to them
 	structVal := r.Indirect(r.ValueOf(val))
@@ -15,28 +28,33 @@ func StructToMap(val interface{}) (map[string]interface{}, bool) {
 	if kind != r.Struct {
 		return nil, false
 	}
-	typ := structVal.Type()
-	mapVal := make(map[string]interface{})
-	for i := 0; i < typ.NumField(); i++ {
-		field := structVal.Field(i)
-		mapVal[typ.Field(i).Name] = field.Interface()
+	sinfo := getStructInfo(structVal)
+	mapVal := make(map[string]interface{}, len(sinfo.FieldsList))
+	for _, field := range sinfo.FieldsList {
+		mapVal[field.Key] = structVal.Field(field.Num).Interface()
 	}
 	return mapVal, true
 }
 
-// v should be a pointer to a struct.
+// MapToStruct converts a map to a struct. It is the inverse of the StructToMap
+// function. For details see StructToMap.
 func MapToStruct(m map[string]interface{}, struc interface{}) error {
 	val := r.Indirect(r.ValueOf(struc))
+	sinfo := getStructInfo(val)
 	for k, v := range m {
-		structField := val.FieldByName(k)
-		if structField.Type().Name() == r.TypeOf(v).Name() {
-			structField.Set(r.ValueOf(v))
+		if info, ok := sinfo.FieldsMap[k]; ok {
+			structField := val.Field(info.Num)
+			if structField.Type().Name() == r.TypeOf(v).Name() {
+				structField.Set(r.ValueOf(v))
+			}
 		}
 	}
 	return nil
 }
 
-// Nice copypaste bro _,^
+// FieldsAndValues returns a list field names and a corresponing list of values
+// for the given struct. For details on how the field names are determined please
+// see StructToMap.
 func FieldsAndValues(val interface{}) ([]string, []interface{}, bool) {
 	// indirect so function works with both structs and pointers to them
 	structVal := r.Indirect(r.ValueOf(val))
@@ -44,13 +62,73 @@ func FieldsAndValues(val interface{}) ([]string, []interface{}, bool) {
 	if kind != r.Struct {
 		return nil, nil, false
 	}
-	typ := structVal.Type()
-	fields := []string{}
-	values := []interface{}{}
-	for i := 0; i < typ.NumField(); i++ {
-		field := structVal.Field(i)
-		fields = append(fields, typ.Field(i).Name)
-		values = append(values, field.Interface())
+	sinfo := getStructInfo(structVal)
+	fields := make([]string, len(sinfo.FieldsList))
+	values := make([]interface{}, len(sinfo.FieldsList))
+	for i, info := range sinfo.FieldsList {
+		field := structVal.Field(info.Num)
+		fields[i] = info.Key
+		values[i] = field.Interface()
 	}
 	return fields, values, true
+}
+
+var structMapMutex sync.RWMutex
+var structMap = make(map[r.Type]*structInfo)
+
+type fieldInfo struct {
+	Key string
+	Num int
+}
+
+type structInfo struct {
+	// FieldsMap is used to access fields by their key
+	FieldsMap map[string]fieldInfo
+	// FieldsList allows iteration over the fields in their struct order.
+	FieldsList []fieldInfo
+}
+
+func getStructInfo(v r.Value) *structInfo {
+	st := r.Indirect(v).Type()
+	structMapMutex.RLock()
+	sinfo, found := structMap[st]
+	structMapMutex.RUnlock()
+	if found {
+		return sinfo
+	}
+
+	n := st.NumField()
+	fieldsMap := make(map[string]fieldInfo, n)
+	fieldsList := make([]fieldInfo, 0, n)
+	for i := 0; i != n; i++ {
+		field := st.Field(i)
+		info := fieldInfo{Num: i}
+		tag := field.Tag.Get("cql")
+		// If there is no cql specific tag and there are no other tags
+		// set the cql tag to the whole field tag
+		if tag == "" && strings.Index(string(field.Tag), ":") < 0 {
+			tag = string(field.Tag)
+		}
+		if tag != "" {
+			info.Key = tag
+		} else {
+			info.Key = field.Name
+		}
+
+		if _, found = fieldsMap[info.Key]; found {
+			msg := fmt.Sprintf("Duplicated key '%s' in struct %s", info.Key, st.String())
+			panic(msg)
+		}
+
+		fieldsList = append(fieldsList, info)
+		fieldsMap[info.Key] = info
+	}
+	sinfo = &structInfo{
+		fieldsMap,
+		fieldsList,
+	}
+	structMapMutex.Lock()
+	structMap[st] = sinfo
+	structMapMutex.Unlock()
+	return sinfo
 }

--- a/reflect/reflect.go
+++ b/reflect/reflect.go
@@ -20,7 +20,7 @@ import (
 //   Field int
 //
 //   // Field appears in the resulting map as key "myName"
-//   // Field int "myName"
+//   Field int "myName"
 func StructToMap(val interface{}) (map[string]interface{}, bool) {
 	// indirect so function works with both structs and pointers to them
 	structVal := r.Indirect(r.ValueOf(val))

--- a/reflect/reflect_test.go
+++ b/reflect/reflect_test.go
@@ -1,0 +1,179 @@
+package reflect
+
+import (
+	"github.com/gocql/gocql"
+
+	"testing"
+)
+
+type Tweet struct {
+	Timeline      string
+	ID            gocql.UUID  `cql:"id"`
+	Text          string      "teXt"
+	OriginalTweet *gocql.UUID `json:"origin"`
+}
+
+func TestStructToMap(t *testing.T) {
+	//Test that if the value is not a struct we return nil, false
+	m, ok := StructToMap("str")
+	if m != nil {
+		t.Error("map is not nil when val is a string")
+	}
+	if ok {
+		t.Error("ok result from StructToMap when the val is a string")
+
+	}
+
+	tweet := Tweet{
+		"t",
+		gocql.TimeUUID(),
+		"hello gocassa",
+		nil,
+	}
+
+	m, ok = StructToMap(tweet)
+	if !ok {
+		t.Error("ok is false for a tweet")
+	}
+
+	if m["Timeline"] != tweet.Timeline {
+		t.Errorf("Expected %s but got %s", tweet.Timeline, m["Timeline"])
+	}
+
+	if m["id"] != tweet.ID {
+		t.Errorf("Expected %s but got %s", tweet.ID, m["id"])
+	}
+	if m["teXt"] != tweet.Text {
+		t.Errorf("Expected %s but got %s", tweet.Text, m["teXt"])
+	}
+	if m["OriginalTweet"] != tweet.OriginalTweet {
+		t.Errorf("Expected %v but got %s", tweet.OriginalTweet, m["OriginalTweet"])
+	}
+
+	id := gocql.TimeUUID()
+	tweet.OriginalTweet = &id
+	m, _ = StructToMap(tweet)
+	if m["OriginalTweet"] != tweet.OriginalTweet {
+		t.Errorf("Expected nil but got %s", m["OriginalTweet"])
+	}
+}
+
+func TestMapToStruct(t *testing.T) {
+
+	m := make(map[string]interface{})
+	assert := func() {
+		tweet := Tweet{}
+		if err := MapToStruct(m, &tweet); err != nil {
+			t.Fatal(err.Error())
+		}
+		timeline, ok := m["Timeline"]
+		if ok {
+			if timeline != tweet.Timeline {
+				t.Errorf("Expected timeline to be %s but got %s", timeline, tweet.Timeline)
+			}
+		} else {
+			if "" != tweet.Timeline {
+				t.Errorf("Expected timeline to be empty but got %s", tweet.Timeline)
+			}
+		}
+		id, ok := m["id"]
+		if ok {
+			if id != tweet.ID {
+				t.Errorf("Expected id to be %s but got %s", id, tweet.ID)
+			}
+		} else {
+			var emptyID gocql.UUID
+			if emptyID != tweet.ID {
+				t.Errorf("Expected id to be empty but got %s", tweet.ID)
+			}
+		}
+		text, ok := m["teXt"]
+		if ok {
+			if text != tweet.Text {
+				t.Errorf("Expected text to be %s but got %s", text, tweet.Text)
+			}
+		} else {
+			if "" != tweet.Text {
+				t.Errorf("Expected text to be empty but got %s", tweet.Text)
+			}
+		}
+
+		originalTweet, ok := m["OriginalTweet"]
+		if ok {
+			if originalTweet != tweet.OriginalTweet {
+				t.Errorf("Expected original tweet to be %s but got %s",
+					originalTweet, tweet.OriginalTweet)
+			}
+		} else {
+			if nil != tweet.OriginalTweet {
+				t.Errorf("Expected original tweet to be empty but got %s",
+					tweet.OriginalTweet)
+			}
+		}
+	}
+
+	assert()
+	m["Timeline"] = "timeline"
+	assert()
+	m["id"] = gocql.TimeUUID()
+	assert()
+	m["text"] = "Hello gocassa"
+	assert()
+	id := gocql.TimeUUID()
+	m["OriginalTweet"] = &id
+	assert()
+}
+
+func TestFieldsAndValues(t *testing.T) {
+	var emptyUUID gocql.UUID
+	id := gocql.TimeUUID()
+	var nilID *gocql.UUID
+	var tests = []struct {
+		tweet  Tweet
+		fields []string
+		values []interface{}
+	}{
+		{
+			Tweet{},
+			[]string{"Timeline", "id", "teXt", "OriginalTweet"},
+			[]interface{}{"", emptyUUID, "", nilID},
+		},
+		{
+			Tweet{"timeline1", id, "hello gocassa", &id},
+			[]string{"Timeline", "id", "teXt", "OriginalTweet"},
+			[]interface{}{"timeline1", id, "hello gocassa", &id},
+		},
+	}
+	for _, test := range tests {
+		fields, values, _ := FieldsAndValues(test.tweet)
+		assertFieldsEqual(t, test.fields, fields)
+		assertValuesEqual(t, test.values, values)
+	}
+}
+
+func assertFieldsEqual(t *testing.T, a, b []string) {
+	if len(a) != len(b) {
+		t.Errorf("expected fields %v but got %v", a, b)
+		return
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			t.Errorf("expected fields %v but got %v", a, b)
+		}
+	}
+}
+
+func assertValuesEqual(t *testing.T, a, b []interface{}) {
+	if len(a) != len(b) {
+		t.Errorf("expected values %v but got %v different length", a, b)
+		return
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			t.Errorf("expected values %v but got %v a[i] = %v and b[i] = %v", a, b, a[i], b[i])
+			return
+		}
+	}
+}


### PR DESCRIPTION
The patch allows the user to control how a field is mapped to a cassandra column by using struct tags.

For details on the mapping see the documentation of StructToMap
