### PR TITLE
Add optional parameters for Table constructors

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -14,11 +14,11 @@ type Connection interface {
 
 // KeySpace is used to obtain tables from.
 type KeySpace interface {
-	MapTable(tableName, id string, row interface{}) MapTable
-	MultimapTable(tableName, fieldToIndexBy, uniqueKey string, row interface{}) MultimapTable
-	TimeSeriesTable(tableName, timeField, uniqueKey string, bucketSize time.Duration, row interface{}) TimeSeriesTable
-	MultiTimeSeriesTable(tableName, fieldToIndexByField, timeField, uniqueKey string, bucketSize time.Duration, row interface{}) MultiTimeSeriesTable
-	Table(tableName string, row interface{}, keys Keys) Table
+	MapTable(tableName, id string, row interface{}, opts ...TableOptions) MapTable
+	MultimapTable(tableName, fieldToIndexBy, uniqueKey string, row interface{}, opts ...TableOptions) MultimapTable
+	TimeSeriesTable(tableName, timeField, uniqueKey string, bucketSize time.Duration, row interface{}, opts ...TableOptions) TimeSeriesTable
+	MultiTimeSeriesTable(tableName, fieldToIndexByField, timeField, uniqueKey string, bucketSize time.Duration, row interface{}, opts ...TableOptions) MultiTimeSeriesTable
+	Table(tableName string, row interface{}, keys Keys, opts ...TableOptions) Table
 	// DebugMode enables/disables debug mode depending on the value of the input boolean.
 	// When DebugMode is enabled, all built CQL statements are printe to stdout.
 	DebugMode(bool)

--- a/keyspace.go
+++ b/keyspace.go
@@ -25,9 +25,15 @@ func (k *k) DebugMode(b bool) {
 	k.debugMode = b
 }
 
-func (k *k) Table(name string, entity interface{}, keys Keys) Table {
-	n := name + "__" + strings.Join(keys.PartitionKeys, "_") + "__" + strings.Join(keys.ClusteringColumns, "_")
-	return k.rawTable(n, entity, keys)
+func (k *k) Table(name string, entity interface{}, keys Keys, opts ...TableOptions) Table {
+	options := mergeTableOptions(opts...)
+
+	// Construct a CQL table name if not provided
+	if options.TableName == "" {
+		options.TableName = name + "__" + strings.Join(keys.PartitionKeys, "_") + "__" + strings.Join(keys.ClusteringColumns, "_")
+	}
+
+	return k.rawTable(options.TableName, entity, keys)
 }
 
 func (k *k) rawTable(name string, entity interface{}, keys Keys) Table {
@@ -46,9 +52,16 @@ func (k *k) table(name string, entity interface{}, fieldSource map[string]interf
 	}
 }
 
-func (k *k) MapTable(name, id string, row interface{}) MapTable {
+func (k *k) MapTable(name, id string, row interface{}, opts ...TableOptions) MapTable {
+	options := mergeTableOptions(opts...)
+
+	// Construct a CQL table name if not provided
+	if options.TableName == "" {
+		options.TableName = fmt.Sprintf("%s_map_%s", name, id)
+	}
+
 	return &mapT{
-		t: k.rawTable(fmt.Sprintf("%s_map_%s", name, id), row, Keys{
+		t: k.rawTable(options.TableName, row, Keys{
 			PartitionKeys: []string{id},
 		}).(*t),
 		idField: id,
@@ -59,9 +72,16 @@ func (k *k) SetKeysSpaceName(name string) {
 	k.name = name
 }
 
-func (k *k) MultimapTable(name, fieldToIndexBy, id string, row interface{}) MultimapTable {
+func (k *k) MultimapTable(name, fieldToIndexBy, id string, row interface{}, opts ...TableOptions) MultimapTable {
+	options := mergeTableOptions(opts...)
+
+	// Construct a CQL table name if not provided
+	if options.TableName == "" {
+		options.TableName = fmt.Sprintf("%s_multimap_%s_%s", name, fieldToIndexBy, id)
+	}
+
 	return &multimapT{
-		t: k.rawTable(fmt.Sprintf("%s_multimap_%s_%s", name, fieldToIndexBy, id), row, Keys{
+		t: k.rawTable(options.TableName, row, Keys{
 			PartitionKeys:     []string{fieldToIndexBy},
 			ClusteringColumns: []string{id},
 		}).(*t),
@@ -70,14 +90,21 @@ func (k *k) MultimapTable(name, fieldToIndexBy, id string, row interface{}) Mult
 	}
 }
 
-func (k *k) TimeSeriesTable(name, timeField, idField string, bucketSize time.Duration, row interface{}) TimeSeriesTable {
+func (k *k) TimeSeriesTable(name, timeField, idField string, bucketSize time.Duration, row interface{}, opts ...TableOptions) TimeSeriesTable {
+	options := mergeTableOptions(opts...)
+
+	// Construct a CQL table name if not provided
+	if options.TableName == "" {
+		options.TableName = fmt.Sprintf("%s_timeSeries_%s_%s_%s", name, timeField, idField, bucketSize.String())
+	}
+
 	m, ok := toMap(row)
 	if !ok {
 		panic("Unrecognized row type")
 	}
 	m[bucketFieldName] = time.Now()
 	return &timeSeriesT{
-		t: k.table(fmt.Sprintf("%s_timeSeries_%s_%s_%s", name, timeField, idField, bucketSize.String()), row, m, Keys{
+		t: k.table(options.TableName, row, m, Keys{
 			PartitionKeys:     []string{bucketFieldName},
 			ClusteringColumns: []string{timeField, idField},
 		}).(*t),
@@ -87,14 +114,21 @@ func (k *k) TimeSeriesTable(name, timeField, idField string, bucketSize time.Dur
 	}
 }
 
-func (k *k) MultiTimeSeriesTable(name, indexField, timeField, idField string, bucketSize time.Duration, row interface{}) MultiTimeSeriesTable {
+func (k *k) MultiTimeSeriesTable(name, indexField, timeField, idField string, bucketSize time.Duration, row interface{}, opts ...TableOptions) MultiTimeSeriesTable {
+	options := mergeTableOptions(opts...)
+
+	// Construct a CQL table name if not provided
+	if options.TableName == "" {
+		options.TableName = fmt.Sprintf("%s_multiTimeSeries_%s_%s_%s_%s", name, indexField, timeField, idField, bucketSize.String())
+	}
+
 	m, ok := toMap(row)
 	if !ok {
 		panic("Unrecognized row type")
 	}
 	m[bucketFieldName] = time.Now()
 	return &multiTimeSeriesT{
-		t: k.table(fmt.Sprintf("%s_multiTimeSeries_%s_%s_%s_%s", name, indexField, timeField, idField, bucketSize.String()), row, m, Keys{
+		t: k.table(options.TableName, row, m, Keys{
 			PartitionKeys:     []string{indexField, bucketFieldName},
 			ClusteringColumns: []string{timeField, idField},
 		}).(*t),

--- a/table.go
+++ b/table.go
@@ -26,6 +26,11 @@ type tableInfo struct {
 	fieldValues    []interface{}
 }
 
+// TableOptions contains additional optional configuration parameters to be passed to a table
+type TableOptions struct {
+	TableName string
+}
+
 func newTableInfo(keyspace, name string, keys Keys, entity interface{}, fieldSource map[string]interface{}) *tableInfo {
 	cinf := &tableInfo{
 		keyspace:      keyspace,
@@ -209,4 +214,13 @@ func (t t) CreateStatement() (string, error) {
 
 func (t t) Name() string {
 	return t.info.name
+}
+
+// mergeTableOptions is a slight misnomer - if more than one is provided we return the first
+func mergeTableOptions(opts ...TableOptions) TableOptions {
+	if len(opts) < 1 {
+		return TableOptions{}
+	}
+
+	return opts[0]
 }


### PR DESCRIPTION
This is a possible solution for #79, allowing optional parameters to be passed to the table constructors using new `TableOptions` type and updating the functions to be variadic with an optional `opts` param.
- Adds a new `TableOptions` type to contain optional table parameters
- Update keyspace Table constructors to take optional `TableOptions` struct
- Currently only `TableName` is supported - this can be used to override the default table name construction (by concatenating name and table settings) with a custom string
