### PR TITLE
Better error messages

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -7,12 +7,15 @@ import (
 
 // RowNotFoundError is returned by Reads if the Row is not found.
 type RowNotFoundError struct {
-	stmt   string
-	params []interface{}
+	file string
+	line int
 }
 
 func (r RowNotFoundError) Error() string {
-	// This is not optimal at all
-	completCql := fmt.Sprintf(strings.Replace(r.stmt, "?", "%v", -1), r.params...)
-	return "The following query returned no results: " + completCql
+	ss := strings.Split(r.file, "/")
+	f := ""
+	if len(ss) > 0 {
+		f = ss[len(ss)-1]
+	}
+	return fmt.Sprintf("%v:%v: No rows returned", f, r.line)
 }

--- a/op.go
+++ b/op.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"runtime"
 	"strconv"
 )
 
@@ -61,9 +62,10 @@ func (w *singleOp) readOne(qe QueryExecutor, opt Options) error {
 		return err
 	}
 	if len(maps) == 0 {
+		_, f, n, _ := runtime.Caller(3)
 		return RowNotFoundError{
-			stmt:   stmt,
-			params: params,
+			file: f,
+			line: n,
 		}
 	}
 	bytes, err := json.Marshal(maps[0])


### PR DESCRIPTION
Previously the error messages contained the whole statement which returned `RowNotFoundError`.
This was obviously a bit insecure so now the error messages print the filename and line number of the caller:

``` go
query_test.go:163: No rows returned
```
