### PR TITLE
Fix deletion statements with custom table names

### DIFF
--- a/op.go
+++ b/op.go
@@ -160,7 +160,7 @@ func (o *singleOp) generateWrite(opt Options) (string, []interface{}) {
 		vals = append(uvals, whereVals...)
 	case delete:
 		str, vals = generateWhere(o.f.rs)
-		str = fmt.Sprintf("DELETE FROM %s.%s%s", o.f.t.keySpace.name, o.f.t.info.name, str)
+		str = fmt.Sprintf("DELETE FROM %s.%s%s", o.f.t.keySpace.name, o.f.t.Name(), str)
 	case insert:
 		fields, insertVals := keyValues(o.m)
 		str = insertStatement(o.f.t.keySpace.name, o.f.t.Name(), fields, o.f.t.options.Merge(opt))


### PR DESCRIPTION
The statement generator currently uses the auto-generated table name for `DELETE` statements, and ignores the custom table name even if it's specified.
