### PR TITLE
Refactor Op

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -6,11 +6,11 @@ type filter struct {
 }
 
 func (f filter) Update(m map[string]interface{}) Op {
-	return newWriteOp(f.t.keySpace.qe, f, update, m)
+	return newWriteOp(f.t.keySpace.qe, f, updateOpType, m)
 }
 
 func (f filter) Delete() Op {
-	return newWriteOp(f.t.keySpace.qe, f, delete, nil)
+	return newWriteOp(f.t.keySpace.qe, f, deleteOpType, nil)
 }
 
 //
@@ -18,27 +18,17 @@ func (f filter) Delete() Op {
 //
 
 func (f filter) Read(pointerToASlice interface{}) Op {
-	return &op{
-		qe: f.t.keySpace.qe,
-		ops: []singleOp{
-			{
-				f:      f,
-				opType: read,
-				result: pointerToASlice,
-			},
-		},
-	}
+	return &singleOp{
+		qe:     f.t.keySpace.qe,
+		f:      f,
+		opType: readOpType,
+		result: pointerToASlice}
 }
 
 func (f filter) ReadOne(pointer interface{}) Op {
-	return &op{
-		qe: f.t.keySpace.qe,
-		ops: []singleOp{
-			{
-				f:      f,
-				opType: singleRead,
-				result: pointer,
-			},
-		},
-	}
+	return &singleOp{
+		qe:     f.t.keySpace.qe,
+		f:      f,
+		opType: singleReadOpType,
+		result: pointer}
 }

--- a/gocql_backend.go
+++ b/gocql_backend.go
@@ -2,6 +2,7 @@ package gocassa
 
 import (
 	"errors"
+
 	"github.com/gocql/gocql"
 )
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -137,6 +137,9 @@ type Op interface {
 	//    op1.WithOptions(Options{Limit:3}).Add(op2).WithOptions(Options{Limit:2}) // op1 and op2 both have a limit of 2
 	//
 	WithOptions(Options) Op
+	// Preflight performs any pre-execution validation that confirms the op considers itself "valid".
+	// NOTE: Run() and RunAtomically() should call this method before execution, and abort if any errors are returned.
+	Preflight() error
 }
 
 // Danger zone! Do not use this interface unless you really know what you are doing

--- a/mock.go
+++ b/mock.go
@@ -17,8 +17,9 @@ type mockKeySpace struct {
 }
 
 type mockOp struct {
-	options Options
-	funcs   []func(mockOp) error
+	options      Options
+	funcs        []func(mockOp) error
+	preflightErr error
 }
 
 func newOp(f func(mockOp) error) mockOp {
@@ -28,10 +29,7 @@ func newOp(f func(mockOp) error) mockOp {
 }
 
 func (m mockOp) Add(ops ...Op) Op {
-	for _, o := range ops {
-		m.funcs = append(m.funcs, o.(mockOp).funcs...)
-	}
-	return m
+	return multiOp{m}.Add(ops...)
 }
 
 func (m mockOp) Run() error {
@@ -53,6 +51,10 @@ func (m mockOp) WithOptions(opt Options) Op {
 
 func (m mockOp) RunAtomically() error {
 	return m.Run()
+}
+
+func (m mockOp) Preflight() error {
+	return m.preflightErr
 }
 
 func (ks *mockKeySpace) NewTable(name string, entity interface{}, fields map[string]interface{}, keys Keys) Table {

--- a/multiop.go
+++ b/multiop.go
@@ -1,0 +1,58 @@
+package gocassa
+
+import (
+	"errors"
+)
+
+type multiOp []Op
+
+func Noop() Op {
+	return multiOp(nil)
+}
+
+func (mo multiOp) Run() error {
+	if err := mo.Preflight(); err != nil {
+		return err
+	}
+	for _, op := range mo {
+		if err := op.Run(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (mo multiOp) RunAtomically() error {
+	return errors.New("RunAtomically() is not implemented yet")
+}
+
+func (mo multiOp) Add(ops_ ...Op) Op {
+	ops := make([]Op, 0, len(ops_))
+	for _, op := range ops_ {
+		// If any multiOps were passed, flatten them out
+		switch op := op.(type) {
+		case multiOp:
+			ops = append(ops, op...)
+		default:
+			ops = append(ops, op)
+		}
+	}
+	return append(mo, ops...)
+}
+
+func (mo multiOp) WithOptions(opts Options) Op {
+	result := make(multiOp, len(mo))
+	for i, op := range mo {
+		result[i] = op.WithOptions(opts)
+	}
+	return result
+}
+
+func (mo multiOp) Preflight() error {
+	for _, op := range mo {
+		if err := op.Preflight(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/query_test.go
+++ b/query_test.go
@@ -46,6 +46,8 @@ func init() {
 	cluster := gocql.NewCluster(getTestHosts()...)
 	cluster.Consistency = gocql.One
 	cluster.Timeout = 1500 * time.Millisecond // Travis' C* is sloooow
+	cluster.RetryPolicy = &gocql.SimpleRetryPolicy{
+		NumRetries: 3}
 	sess, err := cluster.CreateSession()
 	if err != nil {
 		panic(err)

--- a/query_test.go
+++ b/query_test.go
@@ -6,6 +6,9 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/gocql/gocql"
 )
 
 type Customer struct {
@@ -39,11 +42,16 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	ns, err = ConnectToKeySpace(kname, getTestHosts(), "", "")
+
+	cluster := gocql.NewCluster(getTestHosts()...)
+	cluster.Consistency = gocql.One
+	cluster.Timeout = 1500 * time.Millisecond // Travis' C* is sloooow
+	sess, err := cluster.CreateSession()
 	if err != nil {
 		panic(err)
 	}
-	//ns.DebugMode(true)
+	conn := &connection{q: goCQLBackend{session: sess}}
+	ns = conn.KeySpace(kname)
 }
 
 func TestEq(t *testing.T) {

--- a/table.go
+++ b/table.go
@@ -162,14 +162,14 @@ func (t t) Set(i interface{}) Op {
 	if len(updFields) == 0 {
 		return newWriteOp(t.keySpace.qe, filter{
 			t: t,
-		}, insert, m)
+		}, insertOpType, m)
 	}
 	transformFields(updFields)
 	rels := relations(t.info.keys, m)
 	return newWriteOp(t.keySpace.qe, filter{
 		t:  t,
 		rs: rels,
-	}, update, updFields)
+	}, updateOpType, updFields)
 }
 
 func (t t) Create() error {


### PR DESCRIPTION
Previously, `Op` wasn't really a "useable" interface since there were internal type assertions in many places. This PR makes it into a "proper" `Op` for which there can be many implementations.

A new `Preflight()` method now exists too, which will validate an `Op` considers itself to be valid _before_ it is executed.

This also includes a change to make the tests more resilient on CI. FU Travis :rage:.
