### PR TITLE
Ignore fields tagged with cql:"-"

### DIFF
--- a/reflect/reflect.go
+++ b/reflect/reflect.go
@@ -104,6 +104,9 @@ func getStructInfo(v r.Value) *structInfo {
 		field := st.Field(i)
 		info := fieldInfo{Num: i}
 		tag := field.Tag.Get("cql")
+		if tag == "-" {
+			continue
+		}
 		// If there is no cql specific tag and there are no other tags
 		// set the cql tag to the whole field tag
 		if tag == "" && strings.Index(string(field.Tag), ":") < 0 {

--- a/reflect/reflect_test.go
+++ b/reflect/reflect_test.go
@@ -9,6 +9,7 @@ import (
 type Tweet struct {
 	Timeline      string
 	ID            gocql.UUID  `cql:"id"`
+	Ingored       string      `cql:"-"`
 	Text          string      `teXt`
 	OriginalTweet *gocql.UUID `json:"origin"`
 }
@@ -27,6 +28,7 @@ func TestStructToMap(t *testing.T) {
 	tweet := Tweet{
 		"t",
 		gocql.TimeUUID(),
+		"ignored",
 		"hello gocassa",
 		nil,
 	}
@@ -48,6 +50,9 @@ func TestStructToMap(t *testing.T) {
 	}
 	if m["OriginalTweet"] != tweet.OriginalTweet {
 		t.Errorf("Expected %v but got %s", tweet.OriginalTweet, m["OriginalTweet"])
+	}
+	if _, ok := m["Ignore"]; ok {
+		t.Errorf("Igonred should be empty but got %s instead", m["Ignored"])
 	}
 
 	id := gocql.TimeUUID()
@@ -139,7 +144,7 @@ func TestFieldsAndValues(t *testing.T) {
 			[]interface{}{"", emptyUUID, "", nilID},
 		},
 		{
-			Tweet{"timeline1", id, "hello gocassa", &id},
+			Tweet{"timeline1", id, "ignored", "hello gocassa", &id},
 			[]string{"Timeline", "id", "teXt", "OriginalTweet"},
 			[]interface{}{"timeline1", id, "hello gocassa", &id},
 		},

--- a/reflect/reflect_test.go
+++ b/reflect/reflect_test.go
@@ -115,6 +115,11 @@ func TestMapToStruct(t *testing.T) {
 					tweet.OriginalTweet)
 			}
 		}
+		//Ignored should be always empty
+		if tweet.Ingored != "" {
+			t.Errorf("Expected ignored to be empty but got %s",
+				tweet.Ingored)
+		}
 	}
 
 	assert()
@@ -126,6 +131,8 @@ func TestMapToStruct(t *testing.T) {
 	assert()
 	id := gocql.TimeUUID()
 	m["OriginalTweet"] = &id
+	assert()
+	m["Ignored"] = "ignored"
 	assert()
 }
 


### PR DESCRIPTION
Thanks guys for the great work!
I need to ignore some fields of an existing structure  so I've followed the standard tag "-" as done in the json and xml packages. I've added the functionality and some tests, I think I managed to not to break anything (at least the tests are passing). 
I presume this might be helpful to other people as well. 
