### PR TITLE
Support per-operation consistency levels

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -179,8 +179,12 @@ type Table interface {
 // QueryExecutor actually executes the queries - this is mostly useful for testing/mocking purposes,
 // ignore this otherwise. This library is using github.com/gocql/gocql as the query executor by default.
 type QueryExecutor interface {
+	// Query executes a query and returns the results.  It also takes Options to do things like set consistency
+	QueryWithOptions(opts Options, stmt string, params ...interface{}) ([]map[string]interface{}, error)
 	// Query executes a query and returns the results
 	Query(stmt string, params ...interface{}) ([]map[string]interface{}, error)
+	// Execute executes a DML query. It also takes Options to do things like set consistency
+	ExecuteWithOptions(opts Options, stmt string, params ...interface{}) error
 	// Execute executes a DML query
 	Execute(stmt string, params ...interface{}) error
 	// ExecuteAtomically executs multiple DML queries with a logged batch

--- a/op.go
+++ b/op.go
@@ -53,7 +53,7 @@ func newWriteOp(qe QueryExecutor, f filter, opType uint8, m map[string]interface
 
 func (w *singleOp) read() error {
 	stmt, params := w.generateRead(w.options)
-	maps, err := w.qe.Query(stmt, params...)
+	maps, err := w.qe.QueryWithOptions(w.options, stmt, params...)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (w *singleOp) read() error {
 
 func (w *singleOp) readOne() error {
 	stmt, params := w.generateRead(w.options)
-	maps, err := w.qe.Query(stmt, params...)
+	maps, err := w.qe.QueryWithOptions(w.options, stmt, params...)
 	if err != nil {
 		return err
 	}
@@ -86,7 +86,7 @@ func (w *singleOp) readOne() error {
 
 func (w *singleOp) write() error {
 	stmt, params := w.generateWrite(w.options)
-	return w.qe.Execute(stmt, params...)
+	return w.qe.ExecuteWithOptions(w.options, stmt, params...)
 }
 
 func (o *singleOp) Run() error {

--- a/options.go
+++ b/options.go
@@ -1,6 +1,7 @@
 package gocassa
 
 import (
+	"github.com/gocql/gocql"
 	"time"
 )
 
@@ -31,6 +32,8 @@ type Options struct {
 	TableName string
 	// ClusteringOrder specifies the clustering order during table creation. If empty, it is omitted and the defaults are used.
 	ClusteringOrder []ClusteringOrderColumn
+	// Consistency specifies the consistency level. If nil, it is considered not set
+	Consistency *gocql.Consistency
 }
 
 // Returns a new Options which is a right biased merge of the two initial Options.
@@ -53,6 +56,10 @@ func (o Options) Merge(neu Options) Options {
 	if neu.ClusteringOrder != nil {
 		ret.ClusteringOrder = neu.ClusteringOrder
 	}
+	if neu.Consistency != nil {
+		ret.Consistency = neu.Consistency
+	}
+
 	return ret
 }
 


### PR DESCRIPTION
This gives more control, e.g. if you want most reads to be eventually consistent but some to be highly consistent.

There is a new Option field: Consistency.  Two new QueryExecutor functions take an Options argument and pass that through to gocql query: QueryWithOptions() and ExecuteWithOptions().  If not set specified, the default consistency level (currently "One") will be used.

Let me know if you have suggestions on the interface.  I didn't want to break the existing Query() and Execute() interface, but the two new methods makes this a little clunky.
