### PR TITLE
Allow creating tables with compound keys

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -3,10 +3,11 @@ package gocassa
 import (
 	"errors"
 	"fmt"
-	"github.com/gocql/gocql"
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/gocql/gocql"
 )
 
 // CREATE TABLE users (
@@ -27,7 +28,7 @@ import (
 // );
 //
 
-func createTable(keySpace, cf string, partitionKeys, colKeys []string, fields []string, values []interface{}, order []ClusteringOrderColumn) (string, error) {
+func createTable(keySpace, cf string, partitionKeys, colKeys []string, fields []string, values []interface{}, order []ClusteringOrderColumn, compoundKey bool) (string, error) {
 	firstLine := fmt.Sprintf("CREATE TABLE %v.%v (", keySpace, cf)
 	fieldLines := []string{}
 	for i, _ := range fields {
@@ -38,9 +39,14 @@ func createTable(keySpace, cf string, partitionKeys, colKeys []string, fields []
 		l := "    " + strings.ToLower(fields[i]) + " " + typeStr
 		fieldLines = append(fieldLines, l)
 	}
-	str := "    PRIMARY KEY ((%v) %v)"
-	if len(colKeys) > 0 {
+	//key generation
+	str := ""
+	if len(colKeys) > 0 { //key (or composite key) + clustering columns
 		str = "    PRIMARY KEY ((%v), %v)"
+	} else if compoundKey { //compound key just one set of parenthesis
+		str = "    PRIMARY KEY (%v %v)"
+	} else { //otherwise is a composite key without colKeys
+		str = "    PRIMARY KEY ((%v %v))"
 	}
 
 	fieldLines = append(fieldLines, fmt.Sprintf(str, j(partitionKeys), j(colKeys)))

--- a/interfaces.go
+++ b/interfaces.go
@@ -115,6 +115,7 @@ type Filter interface {
 type Keys struct {
 	PartitionKeys     []string
 	ClusteringColumns []string
+	Compound          bool //indicates if the partitions keys are gereated as compound key when no clustering columns are set
 }
 
 // Op is returned by both read and write methods, you have to run them explicitly to take effect.

--- a/table.go
+++ b/table.go
@@ -199,6 +199,7 @@ func (t t) CreateStatement() (string, error) {
 		t.info.fields,
 		t.info.fieldValues,
 		t.options.ClusteringOrder,
+		t.info.keys.Compound,
 	)
 }
 

--- a/table_test.go
+++ b/table_test.go
@@ -191,3 +191,56 @@ func TestCreateStatement(t *testing.T) {
 		t.Fatal(str)
 	}
 }
+func TestKeysCreation(t *testing.T) {
+	cs := ns.Table("composite_keys", Customer{}, Keys{
+		PartitionKeys: []string{"Id", "Name"},
+	})
+	str, err := cs.CreateStatement()
+	if err != nil {
+		t.Fatal(err)
+	}
+	//composite
+	if !strings.Contains(str, "PRIMARY KEY ((id, name ))") {
+		t.Fatal(str)
+	}
+
+	cs = ns.Table("compound_keys", Customer{}, Keys{
+		PartitionKeys: []string{"Id", "Name"},
+		Compound:      true,
+	})
+	str, err = cs.CreateStatement()
+	if err != nil {
+		t.Fatal(err)
+	}
+	//compound
+	if !strings.Contains(str, "PRIMARY KEY (id, name )") {
+		t.Fatal(str)
+	}
+
+	cs = ns.Table("clustering_keys", Customer{}, Keys{
+		PartitionKeys:     []string{"Id"},
+		ClusteringColumns: []string{"Name"},
+	})
+	str, err = cs.CreateStatement()
+	if err != nil {
+		t.Fatal(err)
+	}
+	//with columns
+	if !strings.Contains(str, "PRIMARY KEY ((id), name)") {
+		t.Fatal(str)
+	}
+	//compound gets ignored when using clustering columns
+	cs = ns.Table("clustering_keys", Customer{}, Keys{
+		PartitionKeys:     []string{"Id"},
+		ClusteringColumns: []string{"Name"},
+		Compound:          true,
+	})
+	str, err = cs.CreateStatement()
+	if err != nil {
+		t.Fatal(err)
+	}
+	//with columns
+	if !strings.Contains(str, "PRIMARY KEY ((id), name)") {
+		t.Fatal(str)
+	}
+}


### PR DESCRIPTION
I'm quite new to cassandra so I don't know if I grasp all the details in this issue. I needed to create a certain schema in order to get the best performance when querying against it.  In order to achieve that I needed to create a compound primary key (instead of a composite one), so I've modified a bit the table creation logic and the Keys structure. 

cheers
