### PR TITLE
v1.0.0 RC1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ go:
 
 services:
   - cassandra
+
+before_script:
+  - sleep 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased (v1.0.0-RC1)
+## v1.0.0 - 2015-11-13
 
 ### Added
  - Allow creating tables with compound keys

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## Unreleased (v1.0.0-RC1)
+
+### Added
+ - Allow creating tables with compound keys
+ - Added the `MultimapMultiKeyTable` recipe which allows for CRUD operations on rows filtered by equality of multiple fields.
+
+### Changed
+ - Improved how gocassa handles encoding+decoding, no longer uses the `encoding/json` package and now supports embedded types and type aliases.
+
+### Fixed
+ - Mock tables are now safe for concurrent use
+ - `uint` types are now supported, when generating tables the cassandra `varint` type is used.
+ - Fixed gocassa using `json` tags when decoding results into structs

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ gocassa
 
 Gocassa is a high-level library on top of [gocql](https://github.com/gocql/gocql).
 
+Current version: v1.0.0
+
 Compared to gocql it provides query building, adds data binding, and provides easy-to-use "recipe" tables for common query use-cases. Unlike [cqlc](https://github.com/relops/cqlc), it does not use code generation.
 
 For docs, see: [https://godoc.org/github.com/hailocab/gocassa](https://godoc.org/github.com/hailocab/gocassa)
@@ -169,7 +171,7 @@ EmbeddedType `cql:",squash"`
 
 When encoding maps with non-string keys the key values are automatically converted to strings where possible, however it is recommended that you use strings where possible (for example map[string]T).
 
-##### Rough edges
+##### Troubleshooting
 
 ###### Too long table names
 

--- a/README.md
+++ b/README.md
@@ -117,14 +117,14 @@ For examples on how to do pagination or Update with this table, refer to the exa
 ```
 
 
-##### `MultiMapMultiKey`
+##### `MultiMapMultiKeyTable`
 
-`MultiMapMultiKey` can perform CRUD operations on rows filtered by equality of multiple fields (eg. read a sale based on their `city` , `sellerId` and `Id` of the sale):
+`MultiMapMultiKeyTable` can perform CRUD operations on rows filtered by equality of multiple fields (eg. read a sale based on their `city` , `sellerId` and `Id` of the sale):
 
 ```go
     salePartitionKeys := []Sale{"City"}
     saleClusteringKeys := []Sale{"SellerId","Id"}
-    salesTable := keySpace.MultiMapMultiKey("sale", salePartitionKeys, saleClusteringKeys, Sale{})
+    salesTable := keySpace.MultimapMultiKeyTable("sale", salePartitionKeys, saleClusteringKeys, Sale{})
     // …
     result := Sale{}
     saleFieldCity = salePartitionKeys[0]

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ For examples on how to do pagination or Update with this table, refer to the exa
     saleClusteringKeys := []Sale{"SellerId","Id"}
     salesTable := keySpace.MultiMapMultiKey("sale", salePartitionKeys, saleClusteringKeys, Sale{})
     // …
-    results := Sale{}
+    result := Sale{}
     saleFieldCity = salePartitionKeys[0]
     saleFieldSellerId = saleClusteringKeys[0]
     saleFieldSaleId = saleClusteringKeys[1]
@@ -139,7 +139,7 @@ For examples on how to do pagination or Update with this table, refer to the exa
     id[saleFieldSellerId] = "141-dasf1-124"
     id[saleFieldSaleId] = "512hha232"
 
-    err := salesTable.Read(field, id , &results).Run()
+    err := salesTable.Read(field, id , &result).Run()
 ```
 
 ##### Rough edges

--- a/README.md
+++ b/README.md
@@ -119,14 +119,14 @@ For examples on how to do pagination or Update with this table, refer to the exa
 
 ##### `MultiMapMultiKey`
 
-`MultiMapMultiKey` can perform CRUD operations on rows filtered by equality of multiple fields (eg. read sales based on their `sellerId`, `city` and `Id` of the sale):
+`MultiMapMultiKey` can perform CRUD operations on rows filtered by equality of multiple fields (eg. read a sale based on their `city` , `sellerId` and `Id` of the sale):
 
 ```go
     salePartitionKeys := []Sale{"City"}
     saleClusteringKeys := []Sale{"SellerId","Id"}
     salesTable := keySpace.MultiMapMultiKey("sale", salePartitionKeys, saleClusteringKeys, Sale{})
     // …
-    results := []Sale{}
+    results := Sale{}
     saleFieldCity = salePartitionKeys[0]
     saleFieldSellerId = saleClusteringKeys[0]
     saleFieldSaleId = saleClusteringKeys[1]
@@ -139,7 +139,7 @@ For examples on how to do pagination or Update with this table, refer to the exa
     id[saleFieldSellerId] = "141-dasf1-124"
     id[saleFieldSaleId] = "512hha232"
 
-    err := salesTable.MultiRead(field, id , &results).Run()
+    err := salesTable.Read(field, id , &results).Run()
 ```
 
 ##### Rough edges

--- a/README.md
+++ b/README.md
@@ -116,6 +116,34 @@ For examples on how to do pagination or Update with this table, refer to the exa
     err := salesTable.List("seller-1", yesterdayTime, todayTime, &results).Run()
 ```
 
+#### Encoding/Decoding data structures
+
+When setting `structs` in gocassa the library first converts your value to a map. Each exported field is added to the map unless
+
+- the field's tag is "-", or
+- the field is empty and its tag specifies the "omitempty" option
+
+Each fields default name in the map is the field name but can be specified in the struct field's tag value. The "cql" key in the struct field's tag value is the key name, followed by an optional comma and options. Examples:
+
+```
+// Field is ignored by this package.
+Field int `cql:"-"`
+// Field appears as key "myName".
+Field int `cql:"myName"`
+// Field appears as key "myName" and
+// the field is omitted from the object if its value is empty,
+// as defined above.
+Field int `cql:"myName,omitempty"`
+// Field appears as key "Field" (the default), but
+// the field is skipped if empty.
+// Note the leading comma.
+Field int `cql:",omitempty"`
+// All fields in the EmbeddedType are squashed into the parent type.
+EmbeddedType `cql:",squash"`
+```
+
+When encoding maps with non-string keys the key values are automatically converted to strings where possible, however it is recommended that you use strings where possible (for example map[string]T).
+
 ##### Rough edges
 
 ###### Too long table names

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ func main() {
     if err != nil {
         panic(err)
     }
-    salesTable := keySpace.Table("sale", Sale{}, gocassa.Keys{
+    salesTable := keySpace.Table("sale", &Sale{}, gocassa.Keys{
         PartitionKeys: []string{"Id"},
     })
 
@@ -71,7 +71,7 @@ func main() {
 
 ```go
     // …
-    salesTable := keySpace.MapTable("sale", "Id", Sale{})
+    salesTable := keySpace.MapTable("sale", "Id", &Sale{})
     result := Sale{}
     salesTable.Read("sale-1", &result).Run()
 }
@@ -85,7 +85,7 @@ Read, Set, Update, and Delete all happen by "Id".
 `MultimapTable` can list rows filtered by equality of a single field (eg. list sales based on their `sellerId`):
 
 ```go
-    salesTable := keySpace.MultimapTable("sale", "SellerId", "Id", Sale{})
+    salesTable := keySpace.MultimapTable("sale", "SellerId", "Id", &Sale{})
     // …
     results := []Sale{}
     err := salesTable.List("seller-1", nil, 0, &results).Run()
@@ -99,7 +99,7 @@ For examples on how to do pagination or Update with this table, refer to the exa
 `TimeSeriesTable` provides an interface to list rows within a time interval:
 
 ```go
-    salesTable := keySpace.TimeSeriesTable("sale", "Created", "Id", Sale{}, 24 * time.Hour)
+    salesTable := keySpace.TimeSeriesTable("sale", "Created", "Id", &Sale{}, 24 * time.Hour)
     //...
     results := []Sale{}
     err := salesTable.List(yesterdayTime, todayTime, &results).Run()
@@ -110,7 +110,7 @@ For examples on how to do pagination or Update with this table, refer to the exa
 `MultiTimeSeriesTable` is like a cross between `MultimapTable` and `TimeSeriesTable`. It can list rows within a time interval, and filtered by equality of a single field. The following lists sales in a time interval, by a certain seller:
 
 ```go
-    salesTable := keySpace.MultiTimeSeriesTable("sale", "SellerId", "Created", "Id", Sale{}, 24 * time.Hour)
+    salesTable := keySpace.MultiTimeSeriesTable("sale", "SellerId", "Created", "Id", &Sale{}, 24 * time.Hour)
     //...
     results := []Sale{}
     err := salesTable.List("seller-1", yesterdayTime, todayTime, &results).Run()

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For docs, see: [https://godoc.org/github.com/hailocab/gocassa](https://godoc.org
 
 Gocassa provides multiple table types with their own unique interfaces:
 - a raw CQL table called simply `Table` - this lets you do pretty much any query imaginable
-- and a number of single purpose 'recipe' tables (`Map`, `Multimap`, `TimeSeries`, `MultiTimeSeries`), which aims to help the user by having a simplified interface tailored to a given common query use case
+- and a number of single purpose 'recipe' tables (`Map`, `Multimap`, `TimeSeries`, `MultiTimeSeries`, `MultiMapMultiKey`), which aims to help the user by having a simplified interface tailored to a given common query use case
 
 ##### `Table`
 
@@ -114,6 +114,32 @@ For examples on how to do pagination or Update with this table, refer to the exa
     //...
     results := []Sale{}
     err := salesTable.List("seller-1", yesterdayTime, todayTime, &results).Run()
+```
+
+
+##### `MultiMapMultiKey`
+
+`MultiMapMultiKey` can perform CRUD operations on rows filtered by equality of multiple fields (eg. read sales based on their `sellerId`, `city` and `Id` of the sale):
+
+```go
+    salePartitionKeys := []Sale{"City"}
+    saleClusteringKeys := []Sale{"SellerId","Id"}
+    salesTable := keySpace.MultiMapMultiKey("sale", salePartitionKeys, saleClusteringKeys, Sale{})
+    // …
+    results := []Sale{}
+    saleFieldCity = salePartitionKeys[0]
+    saleFieldSellerId = saleClusteringKeys[0]
+    saleFieldSaleId = saleClusteringKeys[1]
+
+    field := make(map[string]interface{})
+    id := make(map[string]interface{})
+
+
+    field[saleFieldCity] = "London"
+    id[saleFieldSellerId] = "141-dasf1-124"
+    id[saleFieldSaleId] = "512hha232"
+
+    err := salesTable.MultiRead(field, id , &results).Run()
 ```
 
 ##### Rough edges

--- a/compare.go
+++ b/compare.go
@@ -1,0 +1,186 @@
+// Copyright (c) 2014 Dataence, LLC. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Taken from github.com/surgebase/compare after package disappeared.
+
+package gocassa
+
+import (
+	"fmt"
+	"reflect"
+)
+
+type comparator func(k1, k2 interface{}) (bool, error)
+
+func builtinLessThan(k1, k2 interface{}) (bool, error) {
+	if reflect.TypeOf(k1) != reflect.TypeOf(k2) {
+		return false, fmt.Errorf("skiplist/BuiltinLessThan: k1.(%s) and k2.(%s) have different types",
+			reflect.TypeOf(k1).Name(), reflect.TypeOf(k2).Name())
+	}
+
+	switch k1 := k1.(type) {
+	case string:
+		return k1 < k2.(string), nil
+
+	case int64:
+		return k1 < k2.(int64), nil
+
+	case int32:
+		return k1 < k2.(int32), nil
+
+	case int16:
+		return k1 < k2.(int16), nil
+
+	case int8:
+		return k1 < k2.(int8), nil
+
+	case int:
+		return k1 < k2.(int), nil
+
+	case float32:
+		return k1 < k2.(float32), nil
+
+	case float64:
+		return k1 < k2.(float64), nil
+
+	case uint:
+		return k1 < k2.(uint), nil
+
+	case uint8:
+		return k1 < k2.(uint8), nil
+
+	case uint16:
+		return k1 < k2.(uint16), nil
+
+	case uint32:
+		return k1 < k2.(uint32), nil
+
+	case uint64:
+		return k1 < k2.(uint64), nil
+
+	case uintptr:
+		return k1 < k2.(uintptr), nil
+	}
+
+	return false, fmt.Errorf("skiplist/BuiltinLessThan: unsupported types for k1.(%s) and k2.(%s)",
+		reflect.TypeOf(k1).Name(), reflect.TypeOf(k2).Name())
+}
+
+func builtinGreaterThan(k1, k2 interface{}) (bool, error) {
+	if reflect.TypeOf(k1) != reflect.TypeOf(k2) {
+		return false, fmt.Errorf("skiplist/BuiltinGreaterThan: k1.(%s) and k2.(%s) have different types",
+			reflect.TypeOf(k1).Name(), reflect.TypeOf(k2).Name())
+	}
+
+	switch k1 := k1.(type) {
+	case string:
+		return k1 > k2.(string), nil
+
+	case int64:
+		return k1 > k2.(int64), nil
+
+	case int32:
+		return k1 > k2.(int32), nil
+
+	case int16:
+		return k1 > k2.(int16), nil
+
+	case int8:
+		return k1 > k2.(int8), nil
+
+	case int:
+		return k1 > k2.(int), nil
+
+	case float32:
+		return k1 > k2.(float32), nil
+
+	case float64:
+		return k1 > k2.(float64), nil
+
+	case uint:
+		return k1 > k2.(uint), nil
+
+	case uint8:
+		return k1 > k2.(uint8), nil
+
+	case uint16:
+		return k1 > k2.(uint16), nil
+
+	case uint32:
+		return k1 > k2.(uint32), nil
+
+	case uint64:
+		return k1 > k2.(uint64), nil
+
+	case uintptr:
+		return k1 > k2.(uintptr), nil
+	}
+
+	return false, fmt.Errorf("skiplist/BuiltinGreaterThan: unsupported types for k1.(%s) and k2.(%s)",
+		reflect.TypeOf(k1).Name(), reflect.TypeOf(k2).Name())
+}
+
+func builtinEqual(k1, k2 interface{}) (bool, error) {
+	if reflect.TypeOf(k1) != reflect.TypeOf(k2) {
+		return false, fmt.Errorf("skiplist/BuiltinEqual: k1.(%s) and k2.(%s) have different types",
+			reflect.TypeOf(k1).Name(), reflect.TypeOf(k2).Name())
+	}
+
+	switch k1 := k1.(type) {
+	case string:
+		return k1 == k2.(string), nil
+
+	case int64:
+		return k1 == k2.(int64), nil
+
+	case int32:
+		return k1 == k2.(int32), nil
+
+	case int16:
+		return k1 == k2.(int16), nil
+
+	case int8:
+		return k1 == k2.(int8), nil
+
+	case int:
+		return k1 == k2.(int), nil
+
+	case float32:
+		return k1 == k2.(float32), nil
+
+	case float64:
+		return k1 == k2.(float64), nil
+
+	case uint:
+		return k1 == k2.(uint), nil
+
+	case uint8:
+		return k1 == k2.(uint8), nil
+
+	case uint16:
+		return k1 == k2.(uint16), nil
+
+	case uint32:
+		return k1 == k2.(uint32), nil
+
+	case uint64:
+		return k1 == k2.(uint64), nil
+
+	case uintptr:
+		return k1 == k2.(uintptr), nil
+	}
+
+	return false, fmt.Errorf("skiplist/BuiltinLessThan: unsupported types for k1.(%s) and k2.(%s)",
+		reflect.TypeOf(k1).Name(), reflect.TypeOf(k2).Name())
+}

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,7 @@
+// Package gocassa is a high-level library on top of gocql
+//
+// Current version: v1.0.0
+// Compared to gocql it provides query building, adds data binding, and provides
+// easy-to-use "recipe" tables for common query use-cases. Unlike cqlc, it does
+// not use code generation.
+package gocassa

--- a/examples/map_table1/map_table1.go
+++ b/examples/map_table1/map_table1.go
@@ -22,7 +22,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	salesTable := keySpace.MapTable("sale", "Id", Sale{})
+	salesTable := keySpace.MapTable("sale", "Id", &Sale{})
 	// Create the table - we ignore error intentionally
 	salesTable.Create()
 

--- a/examples/multimap_table1/multimap_table1.go
+++ b/examples/multimap_table1/multimap_table1.go
@@ -25,7 +25,7 @@ func main() {
 	// "SellerId" is the field we will use to query sales:
 	// MultimapTable enables us to return all the sales where SellerId equals
 	// to a certain value.
-	salesTable := keySpace.MultimapTable("sale", "SellerId", "Id", Sale{})
+	salesTable := keySpace.MultimapTable("sale", "SellerId", "Id", &Sale{})
 	// Create the table - we ignore error intentionally
 	salesTable.Create()
 

--- a/examples/table1/table1.go
+++ b/examples/table1/table1.go
@@ -22,7 +22,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	salesTable := keySpace.Table("sale", Sale{}, gocassa.Keys{
+	salesTable := keySpace.Table("sale", &Sale{}, gocassa.Keys{
 		PartitionKeys: []string{"Id"},
 	})
 	// Create the table - we ignore error intentionally

--- a/generate.go
+++ b/generate.go
@@ -28,7 +28,7 @@ import (
 // );
 //
 
-func createTable(keySpace, cf string, partitionKeys, colKeys []string, fields []string, values []interface{}, order []ClusteringOrderColumn) (string, error) {
+func createTable(keySpace, cf string, partitionKeys, colKeys []string, fields []string, values []interface{}, order []ClusteringOrderColumn, compoundKey bool) (string, error) {
 	firstLine := fmt.Sprintf("CREATE TABLE %v.%v (", keySpace, cf)
 	fieldLines := []string{}
 	for i, _ := range fields {
@@ -39,9 +39,14 @@ func createTable(keySpace, cf string, partitionKeys, colKeys []string, fields []
 		l := "    " + strings.ToLower(fields[i]) + " " + typeStr
 		fieldLines = append(fieldLines, l)
 	}
-	str := "    PRIMARY KEY ((%v) %v)"
-	if len(colKeys) > 0 {
+	//key generation
+	str := ""
+	if len(colKeys) > 0 { //key (or composite key) + clustering columns
 		str = "    PRIMARY KEY ((%v), %v)"
+	} else if compoundKey { //compound key just one set of parenthesis
+		str = "    PRIMARY KEY (%v %v)"
+	} else { //otherwise is a composite key without colKeys
+		str = "    PRIMARY KEY ((%v %v))"
 	}
 
 	fieldLines = append(fieldLines, fmt.Sprintf(str, j(partitionKeys), j(colKeys)))

--- a/generate.go
+++ b/generate.go
@@ -104,6 +104,24 @@ func cassaType(i interface{}) gocql.Type {
 	case Counter:
 		return gocql.TypeCounter
 	}
+
+	// Fallback to using reflection if type not recognised
+	typ := reflect.TypeOf(i)
+	switch typ.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32:
+		return gocql.TypeInt
+	case reflect.Int64:
+		return gocql.TypeBigInt
+	case reflect.String:
+		return gocql.TypeVarchar
+	case reflect.Float32:
+		return gocql.TypeFloat
+	case reflect.Float64:
+		return gocql.TypeDouble
+	case reflect.Bool:
+		return gocql.TypeBoolean
+	}
+
 	return gocql.TypeCustom
 }
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -193,8 +193,12 @@ type Table interface {
 // QueryExecutor actually executes the queries - this is mostly useful for testing/mocking purposes,
 // ignore this otherwise. This library is using github.com/gocql/gocql as the query executor by default.
 type QueryExecutor interface {
+	// Query executes a query and returns the results.  It also takes Options to do things like set consistency
+	QueryWithOptions(opts Options, stmt string, params ...interface{}) ([]map[string]interface{}, error)
 	// Query executes a query and returns the results
 	Query(stmt string, params ...interface{}) ([]map[string]interface{}, error)
+	// Execute executes a DML query. It also takes Options to do things like set consistency
+	ExecuteWithOptions(opts Options, stmt string, params ...interface{}) error
 	// Execute executes a DML query
 	Execute(stmt string, params ...interface{}) error
 	// ExecuteAtomically executs multiple DML queries with a logged batch

--- a/interfaces.go
+++ b/interfaces.go
@@ -129,6 +129,7 @@ type Filter interface {
 type Keys struct {
 	PartitionKeys     []string
 	ClusteringColumns []string
+	Compound          bool //indicates if the partitions keys are gereated as compound key when no clustering columns are set
 }
 
 // Op is returned by both read and write methods, you have to run them explicitly to take effect.

--- a/mock.go
+++ b/mock.go
@@ -192,9 +192,6 @@ func (t *MockTable) Name() string {
 }
 
 func (t *MockTable) getOrCreateRow(rowKey *keyPart) *btree.BTree {
-	t.Lock()
-	defer t.Unlock()
-
 	row := t.rows[rowKey.RowKey()]
 	if row == nil {
 		row = btree.New(2)
@@ -218,6 +215,9 @@ func (t *MockTable) getOrCreateColumnGroup(rowKey, superColumnKey *keyPart) map[
 
 func (t *MockTable) SetWithOptions(i interface{}, options Options) Op {
 	return newOp(func(m mockOp) error {
+		t.Lock()
+		defer t.Unlock()
+
 		columns, ok := toMap(i)
 		if !ok {
 			return errors.New("Can't create: value not understood")
@@ -336,6 +336,9 @@ func (f *MockFilter) keysFromRelations(keys []string) ([]*keyPart, error) {
 
 func (f *MockFilter) UpdateWithOptions(m map[string]interface{}, options Options) Op {
 	return newOp(func(mock mockOp) error {
+		f.table.Lock()
+		defer f.table.Unlock()
+
 		rowKeys, err := f.keysFromRelations(f.table.keys.PartitionKeys)
 		if err != nil {
 			return err

--- a/multimap_multikey_table_test.go
+++ b/multimap_multikey_table_test.go
@@ -1,0 +1,166 @@
+package gocassa
+
+import (
+	"reflect"
+	"testing"
+)
+
+type Store struct {
+	City    string
+	Manager string
+	Id      string
+	Address string
+}
+
+var (
+	tablename  = "store"
+	StoreIndex = []string{"Manager", "Id"}
+	StorePK    = []string{"City"}
+	CityKey    = StorePK[0]
+	ManagerKey = StoreIndex[0]
+	IdKey      = StoreIndex[1]
+)
+
+func TestMultimapMultiKeyTableInsertRead(t *testing.T) {
+	tbl := ns.MultimapMultiKeyTable(tablename+"90", StorePK, StoreIndex, Store{})
+	createIf(tbl.(TableChanger), t)
+	london := Store{
+		City:    "London",
+		Manager: "Joe",
+		Id:      "12412-afa-16956",
+		Address: "Somerset House",
+	}
+	err := tbl.Set(london).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	field := make(map[string]interface{})
+	id := make(map[string]interface{})
+
+	field[CityKey] = "London"
+	id[ManagerKey] = "Joe"
+	id[IdKey] = "12412-afa-16956"
+
+	res := &Store{}
+	err = tbl.Read(field, id, res).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(*res, london) {
+		t.Fatal(*res, london)
+	}
+
+	id[IdKey] = "12412"
+	err = tbl.Read(field, id, res).Run()
+	if err == nil {
+		t.Fatal(*res)
+	}
+	id[IdKey] = "12412-afa-16956"
+	err = tbl.Update(field, id, map[string]interface{}{
+		"Address": "Soho",
+	}).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = tbl.Read(field, id, res).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Address != "Soho" {
+		t.Fatal(*res)
+	}
+
+	list := &[]Store{}
+	err = tbl.List(field, nil, 20, list).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(*list) != 1 {
+		t.Fatal(*list)
+	}
+}
+
+func TestMultimapMultiKeyTableDelete(t *testing.T) {
+	tbl := ns.MultimapMultiKeyTable(tablename+"91", StorePK, StoreIndex, Store{})
+	createIf(tbl.(TableChanger), t)
+	london := Store{
+		City:    "London",
+		Manager: "Joe",
+		Id:      "12412-afa-16956",
+		Address: "Somerset House",
+	}
+	err := tbl.Set(london).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	field := make(map[string]interface{})
+	id := make(map[string]interface{})
+
+	field[CityKey] = "London"
+	id[ManagerKey] = "Joe"
+	id[IdKey] = "12412-afa-16956"
+
+	res := &Store{}
+	err = tbl.Read(field, id, res).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(*res, london) {
+		t.Fatal(*res, london)
+	}
+	err = tbl.Delete(field, id).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = tbl.Read(field, id, res).Run()
+	if err == nil {
+		t.Fatal(res)
+	}
+}
+
+func TestMultimapMultiKeyTableMultiRead(t *testing.T) {
+	tbl := ns.MultimapMultiKeyTable(tablename+"92", StorePK, StoreIndex, Store{})
+	createIf(tbl.(TableChanger), t)
+	london_somer := Store{
+		City:    "London",
+		Manager: "Joe",
+		Id:      "12412-afa-16956",
+		Address: "Somerset House",
+	}
+	err := tbl.Set(london_somer).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	london_soho := Store{
+		City:    "London",
+		Manager: "Joe",
+		Id:      "12412-afa-16957",
+		Address: "Soho",
+	}
+	err = tbl.Set(london_soho).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	field := make(map[string]interface{})
+	id := make(map[string]interface{})
+
+	field[CityKey] = "London"
+	id[ManagerKey] = "Joe"
+
+	stores := &[]Store{}
+	err = tbl.MultiRead(field, id, stores).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(*stores) != 2 {
+		t.Fatalf("Expected to multiread 2 records, got %d", len(*stores))
+	}
+	if !reflect.DeepEqual((*stores)[0], london_somer) {
+		t.Fatalf("Expected to find london_somer, got %v", (*stores)[0])
+	}
+	if !reflect.DeepEqual((*stores)[1], london_soho) {
+		t.Fatalf("Expected to find london_soho, got %v", (*stores)[1])
+	}
+}

--- a/op.go
+++ b/op.go
@@ -53,7 +53,7 @@ func newWriteOp(qe QueryExecutor, f filter, opType uint8, m map[string]interface
 
 func (w *singleOp) read() error {
 	stmt, params := w.generateRead(w.options)
-	maps, err := w.qe.Query(stmt, params...)
+	maps, err := w.qe.QueryWithOptions(w.options, stmt, params...)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (w *singleOp) read() error {
 
 func (w *singleOp) readOne() error {
 	stmt, params := w.generateRead(w.options)
-	maps, err := w.qe.Query(stmt, params...)
+	maps, err := w.qe.QueryWithOptions(w.options, stmt, params...)
 	if err != nil {
 		return err
 	}
@@ -86,7 +86,7 @@ func (w *singleOp) readOne() error {
 
 func (w *singleOp) write() error {
 	stmt, params := w.generateWrite(w.options)
-	return w.qe.Execute(stmt, params...)
+	return w.qe.ExecuteWithOptions(w.options, stmt, params...)
 }
 
 func (o *singleOp) Run() error {

--- a/op_test.go
+++ b/op_test.go
@@ -1,0 +1,97 @@
+package gocassa
+
+import (
+	"reflect"
+	"testing"
+)
+
+type OpTestStruct struct {
+	A string `cql:"id,omitempty"`
+	B int
+	C int `cql:"-"`
+	D map[string]interface{}
+	E []interface{}
+	F []string
+	G []OpTestStructAlias
+
+	OpTestStructEmbed `cql:",squash"`
+}
+
+type OpTestStructEmbed struct {
+	XA int
+	XB OpTestStructAlias
+	XC []string
+}
+
+type OpTestStructAlias string
+
+var opTestRow = map[string]interface{}{
+	"id": "A",
+	"B":  1,
+	"C":  1,
+	"D": map[string]interface{}{
+		"D1": 1,
+		"D2": "2",
+	},
+	"E": []interface{}{
+		"E1",
+		"E2", "E3", 4,
+	},
+	"F": []string{
+		"F1", "F2", "F3",
+	},
+	"G": []string{
+		"F1", "F2", "F3",
+	},
+
+	"XA": 1,
+	"XB": "XB",
+	"XC": []string{
+		"XC1", "XC2",
+	},
+}
+
+var opTestRowExpected = OpTestStruct{
+	A: "A",
+	B: 1,
+	C: 0,
+	D: map[string]interface{}{"D1": 1, "D2": "2"},
+	E: []interface{}{"E1", "E2", "E3", 4},
+	F: []string{"F1", "F2", "F3"},
+	G: []OpTestStructAlias{"F1", "F2", "F3"},
+	OpTestStructEmbed: OpTestStructEmbed{
+		XA: 1,
+		XB: "XB",
+		XC: []string{"XC1", "XC2"},
+	},
+}
+
+func TestDecodeRow(t *testing.T) {
+	var result []OpTestStruct
+
+	err := decodeResult([]map[string]interface{}{opTestRow}, &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result) != 1 {
+		t.Fatalf("Expected 1 results, got %d", len(result))
+	}
+
+	if !reflect.DeepEqual(result, []OpTestStruct{opTestRowExpected}) {
+		t.Fatalf("Did not get expected result")
+	}
+}
+
+func TestDecodeSingleRow(t *testing.T) {
+	var result OpTestStruct
+
+	err := decodeResult(opTestRow, &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(result, opTestRowExpected) {
+		t.Fatalf("Did not get expected result")
+	}
+}

--- a/options.go
+++ b/options.go
@@ -2,6 +2,8 @@ package gocassa
 
 import (
 	"time"
+
+	"github.com/gocql/gocql"
 )
 
 type ColumnDirection bool
@@ -35,6 +37,8 @@ type Options struct {
 	AllowFiltering bool
 	// Select allows you to do partial reads, ie. retrieve only a subset of fields
 	Select []string
+	// Consistency specifies the consistency level. If nil, it is considered not set
+	Consistency *gocql.Consistency
 }
 
 // Returns a new Options which is a right biased merge of the two initial Options.
@@ -64,6 +68,10 @@ func (o Options) Merge(neu Options) Options {
 	if len(neu.Select) > 0 {
 		ret.Select = neu.Select
 	}
+	if neu.Consistency != nil {
+		ret.Consistency = neu.Consistency
+	}
+
 	return ret
 }
 

--- a/reflect/cache.go
+++ b/reflect/cache.go
@@ -96,7 +96,7 @@ func typeFields(t reflect.Type) []field {
 			// Scan f.typ for fields to include.
 			for i := 0; i < f.typ.NumField(); i++ {
 				sf := f.typ.Field(i)
-				if sf.PkgPath != "" { // unexported
+				if sf.PkgPath != "" && !sf.Anonymous { // unexported
 					continue
 				}
 				tag := getTag(sf)

--- a/reflect/cache.go
+++ b/reflect/cache.go
@@ -1,0 +1,254 @@
+package reflect
+
+import (
+	"reflect"
+	"sort"
+	"sync"
+)
+
+// A field represents a single field found in a struct.
+type field struct {
+	name      string
+	nameBytes []byte // []byte(name)
+
+	tag       bool
+	index     []int
+	typ       reflect.Type
+	omitEmpty bool
+	quoted    bool
+}
+
+func fillField(f field) field {
+	f.nameBytes = []byte(f.name)
+
+	return f
+}
+
+// byName sorts field by name, breaking ties with depth,
+// then breaking ties with "name came from tag", then
+// breaking ties with index sequence.
+type byName []field
+
+func (x byName) Len() int { return len(x) }
+
+func (x byName) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
+
+func (x byName) Less(i, j int) bool {
+	if x[i].name != x[j].name {
+		return x[i].name < x[j].name
+	}
+	if len(x[i].index) != len(x[j].index) {
+		return len(x[i].index) < len(x[j].index)
+	}
+	if x[i].tag != x[j].tag {
+		return x[i].tag
+	}
+	return byIndex(x).Less(i, j)
+}
+
+// byIndex sorts field by index sequence.
+type byIndex []field
+
+func (x byIndex) Len() int { return len(x) }
+
+func (x byIndex) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
+
+func (x byIndex) Less(i, j int) bool {
+	for k, xik := range x[i].index {
+		if k >= len(x[j].index) {
+			return false
+		}
+		if xik != x[j].index[k] {
+			return xik < x[j].index[k]
+		}
+	}
+	return len(x[i].index) < len(x[j].index)
+}
+
+// typeFields returns a list of fields that should be recognized for the given type.
+// The algorithm is breadth-first search over the set of structs to include - the top struct
+// and then any reachable anonymous structs.
+func typeFields(t reflect.Type) []field {
+	// Anonymous fields to explore at the current level and the next.
+	current := []field{}
+	next := []field{{typ: t}}
+
+	// Count of queued names for current level and the next.
+	count := map[reflect.Type]int{}
+	nextCount := map[reflect.Type]int{}
+
+	// Types already visited at an earlier level.
+	visited := map[reflect.Type]bool{}
+
+	// Fields found.
+	var fields []field
+
+	for len(next) > 0 {
+		current, next = next, current[:0]
+		count, nextCount = nextCount, map[reflect.Type]int{}
+
+		for _, f := range current {
+			if visited[f.typ] {
+				continue
+			}
+			visited[f.typ] = true
+
+			// Scan f.typ for fields to include.
+			for i := 0; i < f.typ.NumField(); i++ {
+				sf := f.typ.Field(i)
+				if sf.PkgPath != "" { // unexported
+					continue
+				}
+				tag := getTag(sf)
+				if tag == "-" {
+					continue
+				}
+				name, opts := parseTag(tag)
+				if !isValidTag(name) {
+					name = ""
+				}
+				index := make([]int, len(f.index)+1)
+				copy(index, f.index)
+				index[len(f.index)] = i
+
+				ft := sf.Type
+				if ft.Name() == "" && ft.Kind() == reflect.Ptr {
+					// Follow pointer.
+					ft = ft.Elem()
+				}
+
+				// Record found field and index sequence.
+				if name != "" || !sf.Anonymous || ft.Kind() != reflect.Struct {
+					tagged := name != ""
+					if name == "" {
+						name = sf.Name
+					}
+					fields = append(fields, fillField(field{
+						name:      name,
+						tag:       tagged,
+						index:     index,
+						typ:       ft,
+						omitEmpty: opts.Contains("omitempty"),
+					}))
+					if count[f.typ] > 1 {
+						// If there were multiple instances, add a second,
+						// so that the annihilation code will see a duplicate.
+						// It only cares about the distinction between 1 or 2,
+						// so don't bother generating any more copies.
+						fields = append(fields, fields[len(fields)-1])
+					}
+					continue
+				}
+
+				// Record new anonymous struct to explore in next round.
+				nextCount[ft]++
+				if nextCount[ft] == 1 {
+					next = append(next, fillField(field{name: ft.Name(), index: index, typ: ft}))
+				}
+			}
+		}
+	}
+
+	sort.Sort(byName(fields))
+
+	// Delete all fields that are hidden by the Go rules for embedded fields,
+	// except that fields with valid tags are promoted.
+
+	// The fields are sorted in primary order of name, secondary order
+	// of field index length. Loop over names; for each name, delete
+	// hidden fields by choosing the one dominant field that survives.
+	out := fields[:0]
+	for advance, i := 0, 0; i < len(fields); i += advance {
+		// One iteration per name.
+		// Find the sequence of fields with the name of this first field.
+		fi := fields[i]
+		name := fi.name
+		for advance = 1; i+advance < len(fields); advance++ {
+			fj := fields[i+advance]
+			if fj.name != name {
+				break
+			}
+		}
+		if advance == 1 { // Only one field with this name
+			out = append(out, fi)
+			continue
+		}
+		dominant, ok := dominantField(fields[i : i+advance])
+		if ok {
+			out = append(out, dominant)
+		}
+	}
+
+	fields = out
+	sort.Sort(byIndex(fields))
+
+	return fields
+}
+
+// dominantField looks through the fields, all of which are known to
+// have the same name, to find the single field that dominates the
+// others using Go's embedding rules, modified by the presence of
+// valid tags. If there are multiple top-level fields, the boolean
+// will be false: This condition is an error in Go and we skip all
+// the fields.
+func dominantField(fields []field) (field, bool) {
+	// The fields are sorted in increasing index-length order. The winner
+	// must therefore be one with the shortest index length. Drop all
+	// longer entries, which is easy: just truncate the slice.
+	length := len(fields[0].index)
+	tagged := -1 // Index of first tagged field.
+	for i, f := range fields {
+		if len(f.index) > length {
+			fields = fields[:i]
+			break
+		}
+		if f.tag {
+			if tagged >= 0 {
+				// Multiple tagged fields at the same level: conflict.
+				// Return no field.
+				return field{}, false
+			}
+			tagged = i
+		}
+	}
+	if tagged >= 0 {
+		return fields[tagged], true
+	}
+	// All remaining fields have the same length. If there's more than one,
+	// we have a conflict (two fields named "X" at the same level) and we
+	// return no field.
+	if len(fields) > 1 {
+		return field{}, false
+	}
+	return fields[0], true
+}
+
+var fieldCache struct {
+	sync.RWMutex
+	m map[reflect.Type][]field
+}
+
+// cachedTypeFields is like typeFields but uses a cache to avoid repeated work.
+func cachedTypeFields(t reflect.Type) []field {
+	fieldCache.RLock()
+	f := fieldCache.m[t]
+	fieldCache.RUnlock()
+	if f != nil {
+		return f
+	}
+
+	// Compute fields without lock.
+	// Might duplicate effort but won't hold other computations back.
+	f = typeFields(t)
+	if f == nil {
+		f = []field{}
+	}
+
+	fieldCache.Lock()
+	if fieldCache.m == nil {
+		fieldCache.m = map[reflect.Type][]field{}
+	}
+	fieldCache.m[t] = f
+	fieldCache.Unlock()
+	return f
+}

--- a/reflect/reflect_test.go
+++ b/reflect/reflect_test.go
@@ -45,8 +45,8 @@ func TestStructToMap(t *testing.T) {
 	if m["id"] != tweet.ID {
 		t.Errorf("Expected %s but got %s", tweet.ID, m["id"])
 	}
-	if m["teXt"] != tweet.Text {
-		t.Errorf("Expected %s but got %s", tweet.Text, m["teXt"])
+	if m["Text"] != tweet.Text {
+		t.Errorf("Expected %s but got %s", tweet.Text, m["Text"])
 	}
 	if m["OriginalTweet"] != tweet.OriginalTweet {
 		t.Errorf("Expected %v but got %s", tweet.OriginalTweet, m["OriginalTweet"])
@@ -147,12 +147,12 @@ func TestFieldsAndValues(t *testing.T) {
 	}{
 		{
 			Tweet{},
-			[]string{"Timeline", "id", "teXt", "OriginalTweet"},
+			[]string{"Timeline", "id", "Text", "OriginalTweet"},
 			[]interface{}{"", emptyUUID, "", nilID},
 		},
 		{
 			Tweet{"timeline1", id, "ignored", "hello gocassa", &id},
-			[]string{"Timeline", "id", "teXt", "OriginalTweet"},
+			[]string{"Timeline", "id", "Text", "OriginalTweet"},
 			[]interface{}{"timeline1", id, "hello gocassa", &id},
 		},
 	}

--- a/reflect/tags.go
+++ b/reflect/tags.go
@@ -1,0 +1,67 @@
+package reflect
+
+import (
+	"reflect"
+	"strings"
+	"unicode"
+)
+
+const TagName = "cql"
+
+// tagOptions is the string following a comma in a struct field's
+// tag, or the empty string. It does not include the leading comma.
+type tagOptions string
+
+func getTag(sf reflect.StructField) string {
+	return sf.Tag.Get(TagName)
+}
+
+// parseTag splits a struct field's tag into its name and
+// comma-separated options.
+func parseTag(tag string) (string, tagOptions) {
+	if idx := strings.Index(tag, ","); idx != -1 {
+		return tag[:idx], tagOptions(tag[idx+1:])
+	}
+	return tag, tagOptions("")
+}
+
+func isValidTag(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		switch {
+		case strings.ContainsRune("!#$%&()*+-./:<=>?@[]^_{|}~ ", c):
+			// Backslash and quote chars are reserved, but
+			// otherwise any punctuation chars are allowed
+			// in a tag name.
+		default:
+			if !unicode.IsLetter(c) && !unicode.IsDigit(c) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// Contains returns whether checks that a comma-separated list of options
+// contains a particular substr flag. substr must be surrounded by a
+// string boundary or commas.
+func (o tagOptions) Contains(optionName string) bool {
+	if len(o) == 0 {
+		return false
+	}
+	s := string(o)
+	for s != "" {
+		var next string
+		i := strings.Index(s, ",")
+		if i >= 0 {
+			s, next = s[:i], s[i+1:]
+		}
+		if s == optionName {
+			return true
+		}
+		s = next
+	}
+	return false
+}

--- a/relation.go
+++ b/relation.go
@@ -3,8 +3,6 @@ package gocassa
 import (
 	"strings"
 	"time"
-
-	"github.com/surgebase/compare"
 )
 
 const (
@@ -75,15 +73,15 @@ func (r Relation) accept(i interface{}) bool {
 
 	switch r.op {
 	case greaterThan:
-		result, err = compare.BuiltinGreaterThan(a, b)
+		result, err = builtinGreaterThan(a, b)
 	case greaterThanOrEquals:
-		result, err = compare.BuiltinGreaterThan(a, b)
+		result, err = builtinGreaterThan(a, b)
 		result = result || a == b
 	case lesserThanOrEquals:
-		result, err = compare.BuiltinLessThan(a, b)
+		result, err = builtinLessThan(a, b)
 		result = result || a == b
 	case lesserThan:
-		result, err = compare.BuiltinLessThan(a, b)
+		result, err = builtinLessThan(a, b)
 	}
 
 	return err == nil && result

--- a/table.go
+++ b/table.go
@@ -203,6 +203,7 @@ func (t t) CreateStatement() (string, error) {
 		t.info.fields,
 		t.info.fieldValues,
 		t.options.ClusteringOrder,
+		t.info.keys.Compound,
 	)
 }
 

--- a/table_test.go
+++ b/table_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gocql/gocql"
 )
 
 func createIf(cs TableChanger, tes *testing.T) {
@@ -191,6 +193,7 @@ func TestCreateStatement(t *testing.T) {
 		t.Fatal(str)
 	}
 }
+
 func TestAllowFiltering(t *testing.T) {
 	name := "allow_filtering"
 	cs := ns.Table(name, Customer2{}, Keys{
@@ -209,5 +212,83 @@ func TestAllowFiltering(t *testing.T) {
 	stAllow, _ := cs.Where(Eq("", "")).Read(&c2).WithOptions(op).GenerateStatement()
 	if !strings.Contains(stAllow, "ALLOW FILTERING") {
 		t.Error("Allow filtering show be included in the statement")
+	}
+}
+
+// Mock QueryExecutor that keeps track of options passed to it
+type OptionCheckingQE struct {
+	opts *Options
+}
+
+func (qe OptionCheckingQE) QueryWithOptions(opts Options, stmt string, params ...interface{}) ([]map[string]interface{}, error) {
+	qe.opts.Consistency = opts.Consistency
+	return []map[string]interface{}{}, nil
+}
+
+func (qe OptionCheckingQE) Query(stmt string, params ...interface{}) ([]map[string]interface{}, error) {
+	return qe.QueryWithOptions(Options{}, stmt, params...)
+}
+
+func (qe OptionCheckingQE) ExecuteWithOptions(opts Options, stmt string, params ...interface{}) error {
+	qe.opts.Consistency = opts.Consistency
+	return nil
+}
+
+func (qe OptionCheckingQE) Execute(stmt string, params ...interface{}) error {
+	return qe.ExecuteWithOptions(Options{}, stmt, params...)
+}
+
+func (qe OptionCheckingQE) ExecuteAtomically(stmt []string, params [][]interface{}) error {
+	return nil
+}
+
+func TestQueryWithConsistency(t *testing.T) {
+	// It's tricky to verify this against a live DB, so mock out the
+	// query executor and make sure the right options get passed
+	// through
+	resultOpts := Options{}
+	qe := OptionCheckingQE{opts: &resultOpts}
+	conn := &connection{q: qe}
+	ks := conn.KeySpace("some ks")
+	cs := ks.Table("customerWithConsistency", Customer{}, Keys{PartitionKeys: []string{"Id"}})
+	res := &[]Customer{}
+	cons := gocql.Quorum
+	opts := Options{Consistency: &cons}
+
+	q := cs.Where(Eq("Id", 1)).Read(res).WithOptions(opts)
+
+	if err := q.Run(); err != nil {
+		t.Fatal(err)
+	}
+	if resultOpts.Consistency == nil {
+		t.Fatal(fmt.Sprintf("Expected consistency:", cons, "got: nil"))
+	}
+	if resultOpts.Consistency != nil && *resultOpts.Consistency != cons {
+		t.Fatal(fmt.Sprintf("Expected consistency:", cons, "got:", resultOpts.Consistency))
+	}
+}
+
+func TestExecuteWithConsistency(t *testing.T) {
+	resultOpts := Options{}
+	qe := OptionCheckingQE{opts: &resultOpts}
+	conn := &connection{q: qe}
+	ks := conn.KeySpace("some ks")
+	cs := ks.Table("customerWithConsistency2", Customer{}, Keys{PartitionKeys: []string{"Id"}})
+	cons := gocql.All
+	opts := Options{Consistency: &cons}
+
+	// This calls Execute() under the covers
+	err := cs.Set(Customer{
+		Id:   "100",
+		Name: "Joe",
+	}).WithOptions(opts).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resultOpts.Consistency == nil {
+		t.Fatal(fmt.Sprintf("Expected consistency:", cons, "got: nil"))
+	}
+	if resultOpts.Consistency != nil && *resultOpts.Consistency != cons {
+		t.Fatal(fmt.Sprintf("Expected consistency:", cons, "got:", resultOpts.Consistency))
 	}
 }


### PR DESCRIPTION
Preparing release of v1.0.0, changelog:
### Added
- Allow creating tables with compound keys
- Added the `MultimapMultiKeyTable` recipe which allows for CRUD operations on rows filtered by equality of multiple fields.
### Changed
- Improved how gocassa handles encoding+decoding, no longer uses the `encoding/json` package and now supports embedded types and type aliases.
### Fixed
- Mock tables are now safe for concurrent use
- `uint` types are now supported, when generating tables the cassandra `varint` type is used.
- Fixed gocassa using `json` tags when decoding results into structs
