### PR TITLE
Ensure proper ordering in MockTable

### DIFF
--- a/mock_test.go
+++ b/mock_test.go
@@ -65,13 +65,13 @@ func (s *MockSuite) TestTableRead() {
 
 	var users []user
 	s.NoError(s.tbl.Where(Eq("Pk1", 1), Eq("Pk2", 1)).Read(&users).Run())
-	s.Equal([]user{u1, u3, u4}, users)
+	s.Equal([]user{u1, u4, u3}, users)
 
 	s.NoError(s.tbl.Where(Eq("Pk1", 1), Eq("Pk2", 2)).Read(&users).Run())
 	s.Equal([]user{u2}, users)
 
 	s.NoError(s.tbl.Where(Eq("Pk1", 1), In("Pk2", 1, 2)).Read(&users).Run())
-	s.Equal([]user{u1, u3, u4, u2}, users)
+	s.Equal([]user{u1, u4, u3, u2}, users)
 
 	s.NoError(s.tbl.Where(Eq("Pk1", 1), Eq("Pk2", 1), Eq("Ck1", 1)).Read(&users).Run())
 	s.Equal([]user{u1, u4}, users)


### PR DESCRIPTION
Previously keys were constructed by prepending each component in the key, e.g. the partition key `(x, y)` would be end up being `y -> x`. This was done in an attempt to have clever sharing of key parts for queries such as `… WHERE pk1  = 1 AND pk2 = 2 AND ck IN (1, 2, 3)`, which would create three keys `3 -> 2 -> 1`, `2 -> 2 -> 1`, `1 -> 2 -> 1` where `2 -> 1` was 
shared. The unfortunate (ahem) side effect is that the priority of keys ended up being wrong. This has now been replaced by dumb appending scheme instead with no sharing, which should ensure correct priority.

fixes #100
