### PR TITLE
Fixed tests failing due to timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,3 @@ go:
 
 services:
   - cassandra
-
-before_script:
-  - sleep 10

--- a/query_test.go
+++ b/query_test.go
@@ -30,22 +30,10 @@ func init() {
 	kname := "test_ihopeudonthaveakeyspacenamedlikedthis"
 	var err error
 
-	c, err := Connect(getTestHosts(), "", "")
-	if err != nil {
-		panic(err)
-	}
-	err = c.DropKeySpace(kname)
-	if err != nil {
-		panic(err)
-	}
-	err = c.CreateKeySpace(kname)
-	if err != nil {
-		panic(err)
-	}
-
 	cluster := gocql.NewCluster(getTestHosts()...)
 	cluster.Consistency = gocql.One
-	cluster.Timeout = 1500 * time.Millisecond // Travis' C* is sloooow
+	cluster.Timeout = 10 * time.Second               // Travis' C* is sloooow
+	cluster.MaxWaitSchemaAgreement = 2 * time.Minute // travis might be slow
 	cluster.RetryPolicy = &gocql.SimpleRetryPolicy{
 		NumRetries: 3}
 	sess, err := cluster.CreateSession()
@@ -54,6 +42,15 @@ func init() {
 	}
 	conn := &connection{q: goCQLBackend{session: sess}}
 	ns = conn.KeySpace(kname)
+
+	err = conn.DropKeySpace(kname)
+	if err != nil {
+		panic(err)
+	}
+	err = conn.CreateKeySpace(kname)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func TestEq(t *testing.T) {

--- a/reflect/reflect_test.go
+++ b/reflect/reflect_test.go
@@ -8,9 +8,9 @@ import (
 
 type Tweet struct {
 	Timeline      string
-	ID            gocql.UUID  `cql:"id"`
-	Ingored       string      `cql:"-"`
-	Text          string      `teXt`
+	ID            gocql.UUID `cql:"id"`
+	Ingored       string     `cql:"-"`
+	Text          string
 	OriginalTweet *gocql.UUID `json:"origin"`
 }
 

--- a/table_test.go
+++ b/table_test.go
@@ -315,10 +315,10 @@ func TestQueryWithConsistency(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resultOpts.Consistency == nil {
-		t.Fatal(fmt.Sprintf("Expected consistency:", cons, "got: nil"))
+		t.Fatal(fmt.Sprint("Expected consistency:", cons, "got: nil"))
 	}
 	if resultOpts.Consistency != nil && *resultOpts.Consistency != cons {
-		t.Fatal(fmt.Sprintf("Expected consistency:", cons, "got:", resultOpts.Consistency))
+		t.Fatal(fmt.Sprint("Expected consistency:", cons, "got:", resultOpts.Consistency))
 	}
 }
 
@@ -340,9 +340,9 @@ func TestExecuteWithConsistency(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resultOpts.Consistency == nil {
-		t.Fatal(fmt.Sprintf("Expected consistency:", cons, "got: nil"))
+		t.Fatal(fmt.Sprint("Expected consistency:", cons, "got: nil"))
 	}
 	if resultOpts.Consistency != nil && *resultOpts.Consistency != cons {
-		t.Fatal(fmt.Sprintf("Expected consistency:", cons, "got:", resultOpts.Consistency))
+		t.Fatal(fmt.Sprint("Expected consistency:", cons, "got:", resultOpts.Consistency))
 	}
 }


### PR DESCRIPTION
The tests were failing because the keyspace was created with a misconfigured connection.

Also fixes govet.
