### PR TITLE
remove encoding/json (un)marshalling from mock.go

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -2,7 +2,6 @@ package gocassa
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -470,11 +469,7 @@ func (q *MockFilter) Read(out interface{}) Op {
 }
 
 func (q *MockFilter) assignResult(records interface{}, out interface{}) error {
-	bytes, err := json.Marshal(records)
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(bytes, out)
+	return decodeResult(records, out)
 }
 
 func (q *MockFilter) ReadOne(out interface{}) Op {


### PR DESCRIPTION
replace with mapstructure and gocassa/reflect pattern in op.go

see issue: https://github.com/hailocab/gocassa/issues/138
