### PR TITLE
Fixed potential CQL injection vulnerability when using modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## v1.4.0 - 2016-09-05
+
+### Changed
+ - Moved gocassa to GitHub organization
+
+### Fixed
+ - Fixed potential CQL injection vulnerability when using modifiers
+
 ## v1.3.0 - 2016-04-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ gocassa
 
 Gocassa is a high-level library on top of [gocql](https://github.com/gocql/gocql).
 
-Current version: v1.3.0
+Current version: v1.4.0
 
 Compared to gocql it provides query building, adds data binding, and provides easy-to-use "recipe" tables for common query use-cases. Unlike [cqlc](https://github.com/relops/cqlc), it does not use code generation.
 

--- a/doc.go
+++ b/doc.go
@@ -1,6 +1,6 @@
 // Package gocassa is a high-level library on top of gocql
 //
-// Current version: v1.3.0
+// Current version: v1.4.0
 // Compared to gocql it provides query building, adds data binding, and provides
 // easy-to-use "recipe" tables for common query use-cases. Unlike cqlc, it does
 // not use code generation.

--- a/modifiers.go
+++ b/modifiers.go
@@ -3,7 +3,6 @@ package gocassa
 import (
 	"bytes"
 	"fmt"
-	"strings"
 )
 
 // Modifiers are used with update statements.
@@ -106,8 +105,8 @@ func (m Modifier) cql(name string) (string, []interface{}) {
 		str = fmt.Sprintf("%s[?] = ?", name)
 		vals = append(vals, m.args[0], m.args[1])
 	case modifierListRemove:
-		str = fmt.Sprintf("%s = %s - ?", name)
-		vals = append(vals, m.args[0])
+		str = fmt.Sprintf("%s = %s - ?", name, name)
+		vals = append(vals, []interface{}{m.args[0]})
 	case modifierMapSetFields:
 		fields, ok := m.args[0].(map[string]interface{})
 		if !ok {
@@ -142,16 +141,4 @@ func (m Modifier) cql(name string) (string, []interface{}) {
 		}
 	}
 	return str, vals
-}
-
-func printElem(i interface{}) string {
-	switch v := i.(type) {
-	case string:
-		return "'" + escape(v) + "'"
-	}
-	return fmt.Sprintf("%v", i)
-}
-
-func escape(s string) string {
-	return strings.Replace(s, "'", "''", -1)
 }

--- a/modifiers.go
+++ b/modifiers.go
@@ -13,11 +13,8 @@ const (
 	modifierListAppend
 	modifierListSetAtIndex
 	modifierListRemove
-	modifierListRemoveAtIndex
 	modifierMapSetFields
 	modifierMapSetField
-	modifierMapReplace
-	modifierMapDeleteField
 	modifierCounterIncrement
 )
 
@@ -99,41 +96,49 @@ func (m Modifier) cql(name string) (string, []interface{}) {
 	str := ""
 	vals := []interface{}{}
 	switch m.op {
-	// Can not use bind variables here due to "bind variables are not supported inside collection literals" :(
 	case modifierListPrepend:
-		str = fmt.Sprintf("%v = [%v] + %v", name, printElem(m.args[0]), name)
+		str = fmt.Sprintf("%s = ? + %s", name, name)
+		vals = append(vals, []interface{}{m.args[0]})
 	case modifierListAppend:
-		str = fmt.Sprintf("%v = %v + [%v]", name, name, printElem(m.args[0]))
+		str = fmt.Sprintf("%s = %s + ?", name, name)
+		vals = append(vals, []interface{}{m.args[0]})
 	case modifierListSetAtIndex:
-		str = fmt.Sprintf("%v[%v] = %v", name, m.args[0], printElem(m.args[1]))
+		str = fmt.Sprintf("%s[?] = ?", name)
+		vals = append(vals, m.args[0], m.args[1])
 	case modifierListRemove:
-		str = fmt.Sprintf("%v = %v - [%v]", name, name, printElem(m.args[0]))
+		str = fmt.Sprintf("%s = %s - ?", name)
+		vals = append(vals, m.args[0])
 	case modifierMapSetFields:
-		buf := new(bytes.Buffer)
-		buf.WriteString(fmt.Sprintf("%v = %v + ", name, name))
-		ma, ok := m.args[0].(map[string]interface{})
+		fields, ok := m.args[0].(map[string]interface{})
 		if !ok {
 			panic(fmt.Sprintf("Argument for MapSetFields is not a map: %v", m.args[0]))
 		}
-		buf.WriteString("{")
+
+		buf := new(bytes.Buffer)
 		i := 0
-		for k, v := range ma {
+		for k, v := range fields {
 			if i > 0 {
 				buf.WriteString(", ")
 			}
-			buf.WriteString(fmt.Sprintf("%v : %v", printElem(k), printElem(v)))
+
+			fieldStmt, fieldVals := MapSetField(k, v).cql(name)
+			buf.WriteString(fieldStmt)
+			vals = append(vals, fieldVals...)
+
 			i++
 		}
-		buf.WriteString("}")
 		str = buf.String()
 	case modifierMapSetField:
-		str = fmt.Sprintf("%v[%v] = %v", name, printElem(m.args[0]), printElem(m.args[1]))
+		str = fmt.Sprintf("%s[?] = ?", name)
+		vals = append(vals, m.args[0], m.args[1])
 	case modifierCounterIncrement:
 		val := m.args[0].(int)
 		if val > 0 {
-			str = fmt.Sprintf("%v = %v + %v", name, name, printElem(val))
+			str = fmt.Sprintf("%s = %s + ?", name, name)
+			vals = append(vals, val)
 		} else {
-			str = fmt.Sprintf("%v = %v - %v", name, name, printElem(val*-1))
+			str = fmt.Sprintf("%s = %s - ?", name, name)
+			vals = append(vals, -val)
 		}
 	}
 	return str, vals

--- a/query_test.go
+++ b/query_test.go
@@ -278,7 +278,7 @@ func TestUpdateList(t *testing.T) {
 		"Ints":     ListRemove(2),
 		"Int32s":   ListRemove(2),
 		"Int64s":   ListRemove(2),
-		"Float32s": ListRemove(2.22),
+		"Float32s": ListRemove(float32(2.22)),
 		"Float64s": ListRemove(2.22),
 		"Bools":    ListRemove(true),
 	}).Run()


### PR DESCRIPTION
This PR addresses a potential security issue GoCassa when using modifers (such as `MapSetFields`, `ListAppend`). To fix this issue the change ensures that all parameters are bound instead of built into the CQL query.

(I have bumped the version to `v1.4.0` as I believe this should be released as a hotfix ASAP and no version was released when the repo moved to the `gocassa` org)
