### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/keyspace.go
+++ b/keyspace.go
@@ -142,7 +142,7 @@ func (k *k) FlexMultiTimeSeriesTable(name, timeField, idField string, indexField
 	}
 }
 
-// Returns table names in a keyspace
+// Tables returns table names in a keyspace
 func (k *k) Tables() ([]string, error) {
 	const stmt = "SELECT columnfamily_name FROM system.schema_columnfamilies WHERE keyspace_name = ?"
 	maps, err := k.qe.Query(stmt, k.name)

--- a/options.go
+++ b/options.go
@@ -56,7 +56,7 @@ type Options struct {
 	Compressor string
 }
 
-// Returns a new Options which is a right biased merge of the two initial Options.
+// Merge returns a new Options which is a right biased merge of the two initial Options.
 func (o Options) Merge(neu Options) Options {
 	ret := Options{
 		TTL:             o.TTL,


### PR DESCRIPTION
Fix function comments following [Effective Go Guidelines](https://golang.org/doc/effective_go.html#commentary) 