### PR TITLE
fix: correct typo 'unkown' → 'unknown' in error message

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -210,6 +210,6 @@ func cassaTypeToString(t gocql.Type) (string, error) {
 	case gocql.TypeCounter:
 		return "counter", nil
 	default:
-		return "", errors.New("unkown cassandra type")
+		return "", errors.New("unknown cassandra type")
 	}
 }


### PR DESCRIPTION
## Summary
Corrects the typo `unkown cassandra type` → `unknown cassandra type` in `generate.go` line 213.

## Changes
- Fix typo `unkown` → `unknown` in Cassandra type error message

## Testing
- Go build verified on the modified code

---
*Submitted via PR-fast automation (Jah-yee <jydu_seven@outlook.com>)*